### PR TITLE
Fix tests on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 0.4
+  - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/test/array-like.jl
+++ b/test/array-like.jl
@@ -2,7 +2,13 @@ ncclose()
 v1=NetCDF.open(fn1,"v1",mode=NC_WRITE)
 @test typeof(v1)==NetCDF.NcVar{Float64,3}
 @test v1[1,1,1]==x1[1,1,1]
-@test squeeze(v1[2,:,2],3)==x1[2,:,2]
+
+if VERSION >= v"0.5-"
+  @test squeeze(v1[2,:,2],(1,3))==x1[2,:,2]
+else
+  @test squeeze(v1[2,:,2],3)==x1[2,:,2]
+end
+
 @test squeeze(v1[1:end,3,1],(2,3))==x1[1:end,3,1]
 inds=bitrand(size(x1))
 @test v1[inds]==x1[inds]


### PR DESCRIPTION
apparently due to incorrect implementation of squeeze on non-nightly platforms, at least according to [the docs](http://docs.julialang.org/en/release-0.4/stdlib/arrays/#Base.squeeze) and re-enable testing.
