### PR TITLE
split library alias string "libnetcdf-7,netcdf"

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,12 +1,11 @@
 using BinDeps
+using Conda
 
 @BinDeps.setup
-libnetcdf = library_dependency("libnetcdf", aliases = ["libnetcdf4","libnetcdf-7,netcdf"])
+libnetcdf = library_dependency("libnetcdf", aliases = ["libnetcdf4","libnetcdf-7","netcdf"])
 
-using Conda
 provides(Conda.Manager, "libnetcdf", libnetcdf)
-
-provides(AptGet, Dict("libnetcdf-dev"=>libnetcdf), os = :Linux)
-provides(Yum, Dict("netcdf-devel"=>libnetcdf), os = :Linux)
+provides(AptGet, "libnetcdf-dev", libnetcdf, os = :Linux)
+provides(Yum, "netcdf-devel", libnetcdf, os = :Linux)
 
 @BinDeps.install Dict(:libnetcdf => :libnetcdf)


### PR DESCRIPTION
On the Conda Windows library name is `netcdf.dll`. It wasn't recognized because the alias was fused in a single string to the previous alias.

Fixes #22 

Although strangely just applying this patch and running `Pkg.build("NetCDF")` again didn't instantly resolve the issue for me. It worked only after removing all of Conda.jl, don't understand why.
