### PR TITLE
fix typo in doc

### DIFF
--- a/doc/NetCDF.md
+++ b/doc/NetCDF.md
@@ -72,7 +72,7 @@ Closes the file and writes changes to the disk. If argument is omitted, all open
 
 ## Getting information
 
-    nc = netCDF.open(filename, mode=NC_NOWRITE, readdimvar=false)
+    nc = NetCDF.open(filename, mode=NC_NOWRITE, readdimvar=false)
 
 this function returns an object of type NcVar, which contains all file metainformation and attributes. You can browse it, just type
 
@@ -82,13 +82,13 @@ to find out the fields of the type NcVar. Most of the other functions of the med
 
 ## Reading data
 
-    netCDF.readvar(nc, varname, start=[1,1,...], count=[-1,-1,...])
+    NetCDF.readvar(nc, varname, start=[1,1,...], count=[-1,-1,...])
 
 This function returns an array of values read from the file. The first argument is of type NcFile and is the file handler of a previously opened netCDF file. varname is the variable name of the variable to be read. start and count are optional integer arrays of the same length as the number of variable dimensions, giving the starting indices and the number of steps to be read along each dimension. Setting values in the count vector to -1 will cause the function to read all indices of the respective dimension. If the start and count argument are omitted, the whole variable will be read.
 
 ## Writing data
 
-    netCDF.putvar(nc, varname, vals, start=[1,1,...], count=[size(vals)...])
+    NetCDF.putvar(nc, varname, vals, start=[1,1,...], count=[size(vals)...])
 
 This function writes the values from the array vals to a netCDF file. nc is a netCDF file handler of type NcFile, varname the variable name and vals an array with the same dimension as the variable in the netCDF file. The optional parameter start gives the first index in each dimension along which the writing should begin. It is assumed that the input array vals has the same number of dimensions as the and writing happens along these dimensions. However, you can specify the number of values to be written along each dimension by adding an optional count argument, which is a vector whose length equals the number of variable dimensions.
 
@@ -112,7 +112,7 @@ Here *varname* is the name of the variable, *dimlist* an array of type NcDim hol
 
 Having defined the variables, the netCDF file can be created:
 
-    netCDF.create(filename, varlist, gatts=Dict{Any,Any}(),mode=NC_netCDF4)
+    NetCDF.create(filename, varlist, gatts=Dict{Any,Any}(),mode=NC_netCDF4)
 
 Here, filename is the name of the file to be created and varlist an array of NcVar holding the variables that should appear in the file. In the optional argument *gatts* you can specify a Dict containing global attributes and mode is the file type you want to create(NC_netCDF4, NC_CLASSIC_MODEL or NC_64BIT_OFFSET).
 
@@ -121,11 +121,11 @@ Here, filename is the name of the file to be created and varlist an array of NcV
 
 once you have finished reading, writing or editing your files you can close the file with
 
-    netCDF.close(nc)
+    NetCDF.close(nc)
 
 If you just want to synchronize your changes to the disk, run
 
-    netCDF.sync(nc)
+    NetCDF.sync(nc)
 
 where nc is a netCDF file handler.
 


### PR DESCRIPTION
I think that in the docs `netCDF` should be `NetCDF` (e.g. `NetCDF.open` instead of `netCDF.open`).