### PR TITLE
Remove 0.5 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"


### PR DESCRIPTION
The minimal julia Version for NetCDF is 0.6 since ae9e333109a8b6434c12f6194b2c23cf2771f1c7 . 
Therefore 0.5 should not be tested.