### PR TITLE
derive type of dimension variable from its values

### DIFF
--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -594,7 +594,8 @@ function create(name::AbstractString,varlist::Array{NcVar};gatts::Dict=Dict{Any,
     for d in dims
         create_dim(nc, d)
         if (length(d.vals)>0) & (!haskey(nc.vars,d.name))
-            push!(varlist,NcVar{Float64,1,NC_DOUBLE}(id,varida[1],1,length(d.atts),NC_DOUBLE,d.name,[d.dimid],[d],d.atts,-1,(zero(Int32),)))
+            elt = eltype(d.vals)
+            push!(varlist,NcVar{elt,1,jl2nc(elt)}(id,varida[1],1,length(d.atts),jl2nc(elt),d.name,[d.dimid],[d],d.atts,-1,(zero(Int32),)))
         end
     end
 
@@ -881,7 +882,10 @@ function nccreate(fil::AbstractString,varname::AbstractString,dims...;atts::Dict
             if !haskey(nc.dim,dim[i].name)
                 create_dim(nc,dim[i])
                 v.dimids[i] = dim[i].dimid
-                isempty(dim[i].vals) || create_var(nc,NcVar{Float64,1,NC_DOUBLE}(nc.ncid,0,1,length(dim[i].atts),NC_DOUBLE,dim[i].name,[dim[i].dimid],[dim[i]],dim[i].atts,-1,(0,)),mode)
+                if length(dim[i].vals)>0
+                    elt = eltype(dim[i].vals)
+                    create_var(nc,NcVar{elt,1,jl2nc(elt)}(nc.ncid,0,1,length(dim[i].atts),jl2nc(elt),dim[i].name,[dim[i].dimid],[dim[i]],dim[i].atts,-1,(0,)),mode)
+                end
                 dcreate[i] = true
             else
                 v.dimids[i] = nc.dim[dim[i].name].dimid

--- a/test/high.jl
+++ b/test/high.jl
@@ -3,6 +3,7 @@ fn1 = tempname2()
 fn2 = tempname2()
 fn3 = tempname2()
 fn4 = tempname2()
+fn5 = tempname2()
 
 nccreate(fn1,"v1","Dim1",[1,2],Dict("units"=>"deg C"),"Dim2",collect(1:10),"Dim3",20,Dict("max"=>10),
     mode=NC_NETCDF4)
@@ -73,6 +74,12 @@ nccreate(fn4,"scalar")
 a = Array{Float64,0}();a[1]=10.0
 ncwrite(a,fn4,"scalar")
 @test ncread(fn4,"scalar")[1] == a[1]
+
+# Test dimension variable type
+nccreate(fn5, "x5_1", "dim1", collect(Int32, 1:4), Dict("units"=>"m"))
+nccreate(fn5, "x5_2", "dim2", collect(Float32, 1:4), Dict("units"=>"m"))
+@test typeof(ncread(fn5, "dim1")) == Array{Int32, 1}
+@test typeof(ncread(fn5, "dim2")) == Array{Float32, 1}
 ncclose()
 
 # Open file by reading and create new variable

--- a/test/intermediate.jl
+++ b/test/intermediate.jl
@@ -3,6 +3,7 @@ fn1 = tempname2()
 fn2 = tempname2()
 fn3 = tempname2()
 fn4 = tempname2()
+fn5 = tempname2()
 
 # Test Medium level Interface
 # Test Dimension Creation
@@ -98,3 +99,17 @@ nc3 = NetCDF.open(fn3,mode=NC_NOWRITE);
 
 #Test -1 reading full dimension
 NetCDF.readvar(nc1,"v1",start=[1,1,1],count=[-1,-1,-1])
+
+#Test dimension variables type
+dim1 = NcDim("dim1", 4, atts=Dict("units" => "m"), values=collect(Int32,1:4))
+x5_1 = NcVar("x5_1", [dim1], atts=Dict("units" => "m"), t=Int32)
+
+dim2 = NcDim("dim2", 4, atts=Dict("units" => "m"), values=collect(Float32, 1:4))
+x5_2 = NcVar("x5_2", [dim2], atts=Dict("units" => "m"), t=Int32)
+
+nc5 = NetCDF.create(fn5, Array{NcVar, 1}([x5_1, x5_2]))
+NetCDF.close(nc5)
+
+nc5 = NetCDF.open(fn5)
+@test typeof(NetCDF.readvar(nc5, "dim1")) == Array{Int32, 1}
+@test typeof(NetCDF.readvar(nc5, "dim2")) == Array{Float32, 1}


### PR DESCRIPTION
At the moment, NetCDF.jl creates all dimension variables with type NC_DOUBLE. As [Section 4 of the CF convention](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#coordinate-types) or the [official Documentation of NetCDF](https://www.unidata.ucar.edu/software/netcdf/docs/netcdf_data_set_components.html#coordinate_variables) indicate, other NetCDF types are valid.

This pull request changes both `NetCDF.create` and `nccreate` to derive the type of each dimension variable from its values.