### PR TITLE
Update NcFile and NcVar attribute fields when adding attributes

### DIFF
--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -374,10 +374,9 @@ function putatt(nc::NcFile, atts::Dict)
     merge!(nc.gatts, getatts(nc.ncid,NC_GLOBAL,collect(keys(atts))))
 end
 
-function putatt(nc::NcFile, var::NcVar, atts::Dict)
-    @assert var===nc.vars[var.name]
-    putatt(nc.ncid, var.varid, atts)
-    merge!(var.atts, getatts(nc.ncid,var.varid,collect(keys(atts))))
+function putatt(var::NcVar, atts::Dict)
+    putatt(var.ncid, var.varid, atts)
+    merge!(var.atts, getatts(var.ncid,var.varid,collect(keys(atts))))
 end
 
 """
@@ -394,7 +393,7 @@ function putatt(nc::NcFile,varname::AbstractString,atts::Dict)
         nc_redef(nc.ncid)
     end
     if haskey(nc.vars,varname)
-        putatt(nc,nc.vars[varname],atts)
+        putatt(nc.vars[varname],atts)
     else
         putatt(nc,atts)
     end

--- a/src/netcdf_helpers.jl
+++ b/src/netcdf_helpers.jl
@@ -139,9 +139,9 @@ function nc_inq_attname(ncid::Integer, varid::Integer, attnum::Integer)
     return name
 end
 
-function nc_get_att(ncid::Integer, varid::Integer, attnum::Integer)
+function nc_get_att(ncid::Integer, varid::Integer, att::Union{Integer,AbstractString})
     #Reads attribute name, type and number of values
-    name = nc_inq_attname(ncid,varid,attnum)
+    name = typeof(att)<:Integer ? nc_inq_attname(ncid,varid,att) : string(att)
     nc_inq_att(ncid,varid,name,typea,nvals)
     text = nc_get_att(ncid,varid,string(name),typea[1],nvals[1])
     return name, text
@@ -242,6 +242,19 @@ function getatts_all(ncid::Integer, varid::Integer, natts::Integer)
     atts = Dict{Any,Any}()
     for attnum = 0:natts-1
         attname, attval = nc_get_att(ncid, varid, attnum)
+        if ((length(attval)==1) && !(typeof(attval)<:AbstractString))
+            attval = attval[1]
+        end
+        atts[attname] = attval
+    end
+    NC_VERBOSE && println(atts)
+    return atts
+end
+
+function getatts(ncid::Integer, varid::Integer, attnames::Union{AbstractString,AbstractArray})
+    atts = Dict{Any,Any}()
+    for aattname = (typeof(attnames)<:AbstractArray ? attnames : [attnames])
+        attname, attval = nc_get_att(ncid, varid, aattname)
         if ((length(attval)==1) && !(typeof(attval)<:AbstractString))
             attval = attval[1]
         end


### PR DESCRIPTION
Calling ncputatt to add an attribute or adding global attributes when
creating a new file with NetCDF.create would write the attributes to
the file on disk, but it would not update the atts/gatts field of the
corresponding NcVar or NcFile struct. This commit changes this be-
haviour and the appropriate NcVar/NcFile field is now updated to
reflect the changes to the file on disk.