### PR TITLE
Removed error in displaying string array attributes

### DIFF
--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -988,5 +988,14 @@ function tolen(s::AbstractString, l::Integer)
         return s
     end
 end
+function tolen(s::Array{String,1}, l::Number)
+    cs = "["
+    for se = s
+      cs*=string(se,", ")
+    end
+    cs = isempty(s) ? string(cs,']') : string(cs[1:end-2],']')
+    return tolen(cs, l)
+end
+
 
 end # Module

--- a/test/high.jl
+++ b/test/high.jl
@@ -89,5 +89,6 @@ nccreate(fn4, "myvar3", "time", Inf)
 
 ncclose()
 nci = ncinfo(fn1);
+@test show(nci) === nothing
 @test all(isequal.(nci.vars["v1"].atts["Additional String array attribute"], string.("string attribute ",1:20)))
 ncclose()


### PR DESCRIPTION
Added a `tolen` method to handle String arrays. This removes an error in displaying an `NcFile` object having a String array attribute.