### PR TITLE
Newdatatypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/deps/deps.jl
+deps/deps.jl
+deps/build.log
 docs/build/
 docs/site/
 *.jl.cov

--- a/docs/src/strings.md
+++ b/docs/src/strings.md
@@ -33,8 +33,7 @@ Second, historically the `NC_CHAR` type has been used to store compressed data, 
 these char arrays to strings. Anyhow, here is how you can deal with these variable types:
 
 Assume you have a NetCDF variable of type `NC_CHAR` of dimensions (str_len: 10, axis2: 20).
-Calling `x=ncread(...)` or `x=readvar(...)` on this variable will return an `Array{UInt8,2}` with size `(10,20)` as it is represented on disk.
-If you You can either use this data directly (if it is numeric) or convert them to a `Vector{String}` by calling
+Calling `x=ncread(...)` or `x=readvar(...)` on this variable will return an `Array{ASCIIChar,2}` with size `(10,20)` as it is represented on disk. The `ASCIIChar` type is a small wrapper around `UInt8`, needed for dispatch. You can simply convert them to either `Char` or `UInt8` using the `convert` function. The returned array can either be used directly (if it is numeric maybe use `reinterpret(UInt8,x)`) or convert them to a `Vector{String}` by calling
 
     y=nc_char2string(x)
 

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -18,13 +18,13 @@ NC_VERBOSE = false
 #Some constants
 #Define a short ASCIIChar type to map to NC_CHAR,
 #We can not use Julias Char because it has 4 bytes size
-struct ASCIIChar
-  x::UInt8
-end
-Base.show(io::IO,c::ASCIIChar) = print(io,string("ASCIIChar: '",Char(c.x),"'"))
-Base.convert(::Type{Char},c::ASCIIChar) = Char(c.x)
-Base.convert(::Type{UInt8},c::ASCIIChar) = c.x
-Base.String(a::Vector{ASCIIChar})=String(reinterpret(UInt8,a))
+#create a new AbstractChar type to test the fallbacks,
+#this is re-used from the julialang tests
+#https://github.com/JuliaLang/julia/blob/master/test/char.jl#L242
+primitive type ASCIIChar <: AbstractChar 8 end
+ASCIIChar(c::UInt8) = reinterpret(ASCIIChar, c)
+ASCIIChar(c::UInt32) = ASCIIChar(UInt8(c))
+Base.codepoint(c::ASCIIChar) = reinterpret(UInt8, c)
 Base.zero(::Type{ASCIIChar})=ASCIIChar(0)
 
 global const nctype2jltype = Dict(

--- a/src/netcdf_helpers.jl
+++ b/src/netcdf_helpers.jl
@@ -200,7 +200,7 @@ function nc_get_att(ncid::Integer,varid::Integer,name::AbstractString,attype::In
         valsa = zeros(ASCIIChar,attlen+1)
         nc_get_att_text(ncid,varid,name,valsa)
         valsa[end] = ASCIIChar(0)
-        return String(valsa[1:findfirst(isequal(ASCIIChar(0)),valsa)])
+        return String(valsa[1:findfirst(isequal(ASCIIChar(0)),valsa)-1])
     else
         valsa = Array{nctype2jltype[attype]}(undef,attlen)
         return nc_get_att!(ncid,varid,name,valsa)

--- a/test/high.jl
+++ b/test/high.jl
@@ -12,24 +12,18 @@ nccreate(fn1,"vchar","DimChar",20,"Dim2",t=NetCDF.NC_CHAR)
 nccreate(fn2,"v2","Dim1",[1,2,3],Dict("units"=>"deg C"),"Dim2",collect(1:10),"Dim3",20,Dict("max"=>10),
 atts = Dict("a1"=>"varatts"),gatts=Dict("Some global attributes"=>2010))
 nccreate(fn3,"v3","Dim1",3)
-tlist = [Float64, Float32, Int32, Int16, Int8]
 for i = 1:length(tlist)
     nccreate(fn3,"vt$i","Dim2",collect(1:10),t=tlist[i])
 end
 
 ncputatt(fn1,"v1",Dict("Additional String attribute"=>"att"))
 ncputatt(fn1,"global",Dict("Additional global attribute"=>"gatt"))
-ncputatt(fn1,"global",Dict("Additional Int8 attribute"=>Int8(20),
-                           "Additional Int16 attribute"=>Int16(20),
-                           "Additional Int32 attribute"=>Int32(20),
-                           "Additional Float32 attribute"=>Float32(20),
-                           "Additional Float64 attribute"=>Float64(20)))
-ncputatt(fn1,"v1", Dict("Additional Int8 array attribute"=>Int8[i for i in 1:20],
-                        "Additional Int16 array attribute"=>Int16[i for i in 1:20],
-                        "Additional Int32 array attribute"=>Int32[i for i in 1:20],
-                        "Additional Float32 array attribute"=>Float32[i for i in 1:20],
-                        "Additional Float64 array attribute"=>Float64[i for i in 1:20],
-                        "Additional String array attribute"=>String[string("string attribute ",i) for i in 1:20]))
+numberatts = Dict{Any,Any}("Additional $t attribute"=>t(20) for t in tlist)
+numberatts["Additional String attribute"] = "string attribute"
+arrayatts  = Dict{Any,Any}("Additional $t attribute"=>t[i for i in 1:20] for t in tlist)
+arrayatts["Additional String array attribute"] = String[string("string attribute ",i) for i in 1:20]
+ncputatt(fn1,"global",numberatts)
+ncputatt(fn1,"v1",arrayatts)
 
 #First generate the data
 x1 = rand(2,10,20)

--- a/test/intermediate.jl
+++ b/test/intermediate.jl
@@ -21,7 +21,6 @@ vs = NcVar("vstr",d2,t=String)
 vc = NcVar("vchar",[d5,d2],t=NetCDF.NC_CHAR)
 vscal = NcVar("vscal",NcDim[])
 
-tlist = [Float64, Float32, Int32, Int16, Int8]
 vt = Array{NcVar}(undef,length(tlist))
 for i= 1:length(tlist)
       vt[i]=NcVar("vt$i",d2,t = tlist[i])
@@ -34,19 +33,16 @@ nc2 = NetCDF.create(fn2,NcVar[v2,v3,vscal],gatts=Dict("Some global attributes"=>
 nc3 = NetCDF.create(fn3,vt);
 ncunlim = NetCDF.create(fn4,vunlim)
 
+numberatts = Dict{Any,Any}("Additional $t attribute"=>t(20) for t in tlist)
+numberatts["Additional String attribute"] = "string attribute"
+arrayatts  = Dict{Any,Any}("Additional $t attribute"=>t[i for i in 1:20] for t in tlist)
+arrayatts["Additional String attribute"] = String[string("string attribute ",i) for i in 1:20]
+
 #Test Adding attributes
 NetCDF.putatt(nc1,"v1",Dict("Additional String attribute"=>"att"))
 NetCDF.putatt(nc1,"global",Dict("Additional global attribute"=>"gatt"))
-NetCDF.putatt(nc1,"global",Dict("Additional Int8 attribute"=>Int8(20),
-                                "Additional Int16 attribute"=>Int16(20),
-                                "Additional Int32 attribute"=>Int32(20),
-                                "Additional Float32 attribute"=>Float32(20),
-                                "Additional Float64 attribute"=>Float64(20)))
-NetCDF.putatt(nc1,"v1", Dict("Additional Int8 array attribute"=>Int8[i for i in 1:20],
-                             "Additional Int16 array attribute"=>Int16[i for i in 1:20],
-                             "Additional Int32 array attribute"=>Int32[i for i in 1:20],
-                             "Additional Float32 array attribute"=>Float32[i for i in 1:20],
-                             "Additional Float64 array attribute"=>Float64[i for i in 1:20]))
+NetCDF.putatt(nc1,"global",numberatts)
+NetCDF.putatt(nc1,"v1", arrayatts)
 
 
 #Test writing data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,10 @@ function tempname2()
     rm(f)
     f
 end
+tlist = [Int8, UInt8, Int16, UInt16, Int32,UInt32, Int64,UInt64, Float32, Float64]
 
 include("intermediate.jl")
 include("high.jl")
 include("array-like.jl")
 include("chunks.jl")
+nothing


### PR DESCRIPTION
This adds support for more NetCDF data types which are note so commonly used. In order to support both `NC_CHAR` and and `NC_UBYTE`, I introduced a small wrapper `ASCIIChar` around a `UInt8` to avoid dispatch ambiguities. Unfortunately the Julia `Char` type can not be used because it has 4 bytes length. An alternative would also be to use the ascii type from [Strs.jl](https://github.com/JuliaString/Strs.jl) but that seemed a bit to big a dependency for such a small wrapper.

Anyway, I am very open to other suggestions how to solve this. 