### PR TITLE
minor fixes in documentation

### DIFF
--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -9,7 +9,7 @@ NetCDF.open
 ## Getting information
 
 The `NetCDF.open` function returns an object of type `NcFile` which contains meta-Information about the file and associated variables. You can index
-the NcFile object `nc[varname]` to retrieve an NcVar object and retrieve information about it. You can run `names(nc)` to get a list of available variables.
+the `NcFile` object `nc[varname]` to retrieve an `NcVar` object and retrieve information about it. You can run `names(nc)` to get a list of available variables.
 
 Most of the following functions of the medium-level interface will use either an `NcFile` or an `NcVar` object as their first argument.
 
@@ -28,24 +28,24 @@ NetCDF.putvar
 
 ## Creating files
 
-To create a netCDF file you first have to define the dimensions and variables that it is supposed to hold. As representations for netCDF dimensions and variables there are the predefined NcVar and NcDim types. An NcDim object is created by:
+To create a NetCDF file you first have to define the dimensions and variables that it is supposed to hold. As representations for NetCDF dimensions and variables there are the predefined `NcVar` and `NcDim` types. An `NcDim` object is created by:
 
     NcDim(dimname, dimlength, atts=Dict{Any,Any}(), values=[], unlimited=false)
 
 here dimname is the dimension name, dimlength is the dimension length. The optional argument values is a 1D array of values that are written to the dimension variable and the optional argument atts is a Dict holding pairs of attribute names and values. Setting `unlimited=true` creates an unlimited dimension.
 
-After defining the dimensions, you can create NcVar objects with
+After defining the dimensions, you can create `NcVar` objects with
 
     NcVar(varname , dimlist; atts=Dict{Any,Any}(), t=Float64, compress=-1)
 
-Here *varname* is the name of the variable, *dimlist* an array of type NcDim holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type(Int16, Int32, Float32, Float64) which will be translated to(NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in netCDF4 files.
+Here *varname* is the name of the variable, *dimlist* an array of type `NcDim` holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type (`Int16`, `Int32`, `Float32`, `Float64`) which will be translated to (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in NetCDF4 files.
 
 
-Having defined the variables, the netCDF file can be created:
+Having defined the variables, the NetCDF file can be created:
 
-    NetCDF.create(filename, varlist, gatts=Dict{Any,Any}(),mode=NC_netCDF4)
+    NetCDF.create(filename, varlist, gatts=Dict{Any,Any}(),mode=NC_NETCDF4)
 
-Here, filename is the name of the file to be created and varlist an array of NcVar holding the variables that should appear in the file. In the optional argument *gatts* you can specify a Dict containing global attributes and mode is the file type you want to create(NC_netCDF4, NC_CLASSIC_MODEL or NC_64BIT_OFFSET).
+Here, filename is the name of the file to be created and varlist an array of `NcVar` holding the variables that should appear in the file. In the optional argument *gatts* you can specify a Dict containing global attributes and mode is the file type you want to create(`NC_NETCDF4`, `NC_CLASSIC_MODEL` or `NC_64BIT_OFFSET`).
 
 
 ## Miscellaneous
@@ -58,7 +58,7 @@ If you just want to synchronize your changes to the disk, run
 
     NetCDF.sync(nc)
 
-where nc is a netCDF file handler.
+where `nc` is a NetCDF file handle.
 
 ## Interface for creating files
 

--- a/docs/src/strings.md
+++ b/docs/src/strings.md
@@ -1,4 +1,4 @@
-# Short note on reading and writing NC_CHAR and NC_STRING variables
+# Short note on reading and writing `NC_CHAR` and `NC_STRING` variables
 
 There are two common types for storing String data in NetCDF variables. The first is `NC_CHAR`,
 where a 1D array of strings is stored in a 2D `char**` array. Here the user must define the maximum
@@ -6,7 +6,7 @@ string length and add a respective NetCDF dimension. Since NetCDF4 there is the 
  the direct definition of String variables so that an N-dimensional String array directly maps to an N-dimensional
  array in the NetCDF file structure.
 
-## NC_STRING variables
+## `NC_STRING` variables
 
 In this package, the Julia type `String` maps to the `NC_STRING` datatype, which means that creating a variable with any of
 
@@ -23,7 +23,7 @@ NcVar(varname,dims,t=String)
 will result in a NetCDF variable of type `NC_STRING`. You can directly write an `Array{String}` of matching shape to these
 variables. Similarly, calling `ncread` or `NetCDF.readvar` on any of these variables will return an `Array{String}`
 
-## NC_CHAR variables
+## `NC_CHAR` variables
 
 Dealing with `NC_CHAR` variables is a bit more complicated. This has 2 reasons. First, the dimensions of the NetCDF variables
 do not match the dimensions of the resulting string array because of the additional `str_len` (or similar) axis that is introduced in the

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -120,7 +120,7 @@ NcDim(name::AbstractString,values::AbstractArray,atts::Dict;unlimited=false) =
 """
     NcVar
 
-`NcVar{T,N,M}` represents a NetCDF variable. It is a subtype of AbstractArray{T,N}, so normal indexing using `[]`
+`NcVar{T,N,M}` represents a NetCDF variable. It is a subtype of `AbstractArray{T,N}`, so normal indexing using `[]`
 will work for reading and writing data to and from a NetCDF file. `NcVar` objects are returned by `NetCDF.open`, by
 indexing an `NcFile` object (e.g. `myfile["temperature"]`) or, when creating a new file, by its constructor. The type parameter `M`
 denotes the NetCDF data type of the variable, which may or may not correspond to the Julia Data Type.
@@ -151,7 +151,7 @@ list of NetCDF dimensions specified by `dimin`.
 ### Keyword arguments
 
 * `atts` Dictionary representing the variables attributes
-* `t` either a Julia type, (one of `Int16, Int32, Float32, Float64, String`) or a NetCDF data type (`NC_SHORT, NC_INT, NC_FLOAT, NC_DOUBLE, NC_CHAR, NC_STRING`) determines the data type of the variable. Defaults to -1
+* `t` either a Julia type, (one of `Int16`, `Int32`, `Float32`, `Float64`, `String`) or a NetCDF data type (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`, `NC_CHAR`, `NC_STRING`) determines the data type of the variable. Defaults to -1
 * `compress` Integer which sets the compression level of the variable for NetCDF4 files. Defaults to -1 (no compression). Compression levels of 1..9 are valid
 """
 function NcVar(name::AbstractString,dimin::Union{NcDim,Array{NcDim,1}};atts::Dict=Dict{Any,Any}(),t::Union{DataType,Integer}=Float64,compress::Integer=-1,chunksize::Tuple=ntuple(i->zero(Int32),isa(dimin,NcDim) ? 1 : length(dimin)))
@@ -440,8 +440,8 @@ putvar(nc::NcFile,varname::AbstractString,vals::AbstractArray;start=ones(Int,len
 """
     NetCDF.putvar(v::NcVar,vals::Array;start::Vector=ones(Int,length(size(vals))),count::Vector=[size(vals)...])
 
-Writes the values from the array `vals` to a netcdf file. `v` is the NcVar handle of the respective variable and `vals` an array
-with the same dimension as the variable in the netcdf file.
+Writes the values from the array `vals` to a NetCDF file. `v` is the `NcVar` handle of the respective variable and `vals` an array
+with the same dimension as the variable in the NetCDF file.
 
 ### Keyword arguments
 
@@ -600,7 +600,7 @@ Creates a new NetCDF file. Here, `name`
 ### Keyword arguments
 
 * `gatts` a Dict containing global attributes of the NetCDF file
-* `mode` NetCDF file type (NC_NETCDF4, NC_CLASSIC_MODEL or NC_64BIT_OFFSET), defaults to NC_NETCDF4
+* `mode` NetCDF file type (`NC_NETCDF4`, `NC_CLASSIC_MODEL` or `NC_64BIT_OFFSET`), defaults to `NC_NETCDF4`
 """
 function create(name::AbstractString,varlist::Array{NcVar};gatts::Dict=Dict{Any,Any}(),mode::UInt16=NC_NETCDF4)
 
@@ -672,7 +672,7 @@ end
 """
     NetCDF.open(fil::AbstractString,v::AbstractString)
 
-opens a NetCDF variable `v` in the NetCDF file `fil` and returns an `NcVar` handle that implements the AbstractArray interface for reading and writing.
+opens a NetCDF variable `v` in the NetCDF file `fil` and returns an `NcVar` handle that implements the `AbstractArray` interface for reading and writing.
 
 ### Keyword arguments
 
@@ -771,7 +771,7 @@ end
 ncread(fil::AbstractString,vname::AbstractString,start::Array{T,1},count::Array{T,1}) where {T<:Integer}=ncread(fil,vname,start=start,count=count)
 
 """
-ncread!(filename, varname, d)
+    ncread!(filename, varname, d)
 
 reads the values of the variable varname from file filename and writes the results to the pre-allocated array `d`
 
@@ -784,8 +784,8 @@ reads the values of the variable varname from file filename and writes the resul
 
 To read the second slice of a 3D NetCDF variable one can write:
 
-d = zeros(10,10,1)
-ncread!("filename","varname", d, start=[1,1,2], count = [-1,-1,1])
+    d = zeros(10,10,1)
+    ncread!("filename","varname", d, start=[1,1,2], count = [-1,-1,1])
 
 """
 function ncread!(fil::AbstractString,vname::AbstractString,vals::AbstractArray;start::Vector{Int}=ones(Int,ndims(vals)),count::Vector{Int}=[size(vals,i) for i=1:ndims(vals)])
@@ -874,18 +874,18 @@ end
 """
     nccreate (filename, varname, dimensions ...)
 
-Create a variable in an existing netcdf file or generates a new file. `filename` and `varname` are strings.
+Create a variable in an existing NetCDF file or generates a new file. `filename` and `varname` are strings.
 After that follows a list of dimensions. Each dimension entry starts with a dimension name (a String), and
 may be followed by a dimension length, an array with dimension values or a Dict containing dimension attributes.
 Then the next dimension is entered and so on. Have a look at examples/high.jl for an example use.
 
-###Keyword arguments
+### Keyword arguments
 
 - **atts** Dict of attribute names and values to be assigned to the variable created
 - **gatts** Dict of attribute names and values to be written as global attributes
-- **compress** Integer [0..9] setting the compression level of the file, only valid if mode=NC_NETCDF4
-- **t** variable type, currently supported types are: const NC_BYTE, NC_CHAR, NC_SHORT, NC_INT, NC_FLOAT, NC_LONG, NC_DOUBLE
-- **mode** file creation mode, only valid when new file is created, choose one of: NC_NETCDF4, NC_CLASSIC_MODEL, NC_64BIT_OFFSET
+- **compress** Integer [0..9] setting the compression level of the file, only valid if `mode=NC_NETCDF4`
+- **t** variable type, currently supported types are: const `NC_BYTE`, `NC_CHAR`, `NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_LONG`, `NC_DOUBLE`
+- **mode** file creation mode, only valid when new file is created, choose one of: `NC_NETCDF4`, `NC_CLASSIC_MODEL`, `NC_64BIT_OFFSET`
 """
 function nccreate(fil::AbstractString,varname::AbstractString,dims...;atts::Dict=Dict{Any,Any}(),gatts::Dict=Dict{Any,Any}(),compress::Integer=-1,t::Union{DataType,Integer}=NC_DOUBLE,mode::UInt16=NC_NETCDF4,chunksize=(0,))
     # Checking dims argument for correctness


### PR DESCRIPTION
Some fixes in the documentation/docstrings.

- fixed underscores being eliminated from constants like `NC_CHAR` by putting them into backticks, else Documenter interprets the underscores as italic formatting and there seems to be no way of escaping the underscores
- unified spelling of netcdf, netCDF and NetCDF to NetCDF
- consistent use of monospaced formatting for names like `NcVar`
- fixed a few formatting problems due to missing whitespace
- fixed a few typos