### PR TITLE
various small updates, drop julia 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "NetCDF"
+uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
+
+[deps]
+BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+CondaBinDeps = "a9693cdc-2bc8-5703-a9cd-1da358117377"
+Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+
+[compat]
+BinDeps = "≥ 0.8.10"
+CondaBinDeps = "≥ 0.1.0"
+Formatting = "≥ 0.3.2"
+julia = "≥ 0.7.0"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 BinDeps = "≥ 0.8.10"
 CondaBinDeps = "≥ 0.1.0"
 Formatting = "≥ 0.3.2"
-julia = "≥ 0.7.0"
+julia = "≥ 1.0.0"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 CondaBinDeps = "a9693cdc-2bc8-5703-a9cd-1da358117377"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 BinDeps = "≥ 0.8.10"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 NetCDF.jl
-============
+=========
 
-| **Documentation**                                                               | **PackageEvaluator**                                                                            | **Build Status**                                                                                |
-|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-dev-img]][docs-dev-url] | [![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url]  | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] |
+| **Documentation**                                                               | **Build Status**                                                                                |
+|:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
+| [![][docs-dev-img]][docs-dev-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] |
 
 
 NetCDF support for the julia programming language, there is a high-level and a medium-level interface for writing and reading netcdf files.
@@ -64,10 +64,4 @@ This package was originally started and is mostly maintained by Fabian Gans (fga
 [travis-url]: https://travis-ci.org/JuliaGeo/NetCDF.jl
 
 [appveyor-img]: https://ci.appveyor.com/api/projects/status/m9okydt7700kgavi?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/JuliaGeo/netcdf-jl/build/1.0.42
-
-
-[pkg-0.5-img]: http://pkg.julialang.org/badges/NetCDF_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=NetCDFD&ver=0.5
-[pkg-0.6-img]: http://pkg.julialang.org/badges/NetCDF_0.6.svg
-[pkg-0.6-url]: http://pkg.julialang.org/?pkg=NetCDF&ver=0.6
+[appveyor-url]: https://ci.appveyor.com/project/JuliaGeo/netcdf-jl/branch/master

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7
-BinDeps 0.8.10
-CondaBinDeps 0.1.0
-Formatting 0.3.2

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,3 +1,5 @@
+# This file is machine-generated - editing it directly is not advised
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -9,15 +11,15 @@ version = "0.8.10"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "ec61a16eed883ad0cfa002d7489b3ce6d039bb9a"
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "1.4.0"
+version = "2.1.0"
 
 [[Conda]]
 deps = ["Compat", "JSON", "VersionParsing"]
-git-tree-sha1 = "fb86fe40cb5b35990e368709bfdc1b46dbb99dac"
+git-tree-sha1 = "b625d802587c2150c279a40a646fba63f9bd8187"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.1.1"
+version = "1.2.0"
 
 [[CondaBinDeps]]
 deps = ["BinDeps", "Compat", "Conda", "Libdl"]
@@ -34,20 +36,20 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "1df01539a1c952cef21f2d2d1c092c2bcf0177d7"
+git-tree-sha1 = "4d30e889c9f106a51ffa4791a88ffd4765bf20c3"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.6.0"
+version = "0.7.0"
 
 [[Documenter]]
-deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]
-git-tree-sha1 = "9f2135e0e7ecb63f9c3ef73ea15a31d8cdb79bb7"
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
+git-tree-sha1 = "38509269fc99a9bc450fdb9e17e805021f3e5b1b"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.20.0"
+version = "0.22.4"
 
 [[Formatting]]
 deps = ["Compat"]
@@ -56,7 +58,7 @@ uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
 version = "0.3.5"
 
 [[InteractiveUtils]]
-deps = ["LinearAlgebra", "Markdown"]
+deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
@@ -133,7 +135,7 @@ uuid = "30578b45-9adc-5946-b283-645ec420af67"
 version = "0.4.0"
 
 [[UUIDs]]
-deps = ["Random"]
+deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 
 [compat]
-Documenter = "~0.20"
+Documenter = "~0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, NetCDF
 
 makedocs(
     modules = [NetCDF],
-    format = :html,
+    format = Documenter.HTML(),
     sitename = "NetCDF.jl",
     authors = "Fabian Gans and contributors",
     pages = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,10 @@ function tempname2()
 end
 tlist = [Int8, UInt8, Int16, UInt16, Int32,UInt32, Int64,UInt64, Float32, Float64]
 
-include("intermediate.jl")
-include("high.jl")
-include("array-like.jl")
-include("chunks.jl")
+@testset "NetCDF" begin
+    include("intermediate.jl")
+    include("high.jl")
+    include("array-like.jl")
+    include("chunks.jl")
+end
 nothing


### PR DESCRIPTION
It's probably time for a v0.8.0. Looking at https://github.com/JuliaGeo/NetCDF.jl/compare/v0.7.3...master, the ASCIIChar changes are technically breaking. If we are doing a breaking release, I though we might as well drop julia 0.7 support.