### PR TITLE
Remove currentNcFiles and add do-syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/docs/src/highlevel.md
+++ b/docs/src/highlevel.md
@@ -39,13 +39,3 @@ ncputatt
 ```@docs
 nccreate
 ```
-
-## Miscellaneous
-
-```@docs
-ncsync
-```
-
-```@docs
-ncclose
-```

--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -60,6 +60,10 @@ If you just want to synchronize your changes to the disk, run
 
 where `nc` is a NetCDF file handle.
 
+As an alternative, `NetCDF.open` and `NetCDF.create` provide a method accepting a
+function as its first argument. This can be used to make sure the file always get
+properly closed, even if an error occurs while working with the handle. 
+
 ## Interface for creating files
 
 ```@docs

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -60,13 +60,6 @@ Once the file is created we can write the actual data to it:
 ncwrite(rad,fn,"rad");
 ```
 
-This does not yet ensure that the data is actually written to the file, it might still be cached
-by the NetCDF library. In order to write and close the file we run `ncclose`:
-
-```@example 1
-ncclose(fn)
-nothing # hide
-```
 
 Now we assume we just retrieved this radiation NetCDF file and want to get some information about it.
 This is done using `ncinfo`:

--- a/examples/high.jl
+++ b/examples/high.jl
@@ -35,10 +35,6 @@ nccreate("radiation.nc", "rad", "lon", lon, lonatts, "lat", lat, latatts,
 
 ncwrite(rad, "radiation.nc", "rad")
 
-# And close the file
-
-ncclose("radiation.nc")
-
 # Reading the whole dataset is done by:
 
 x = ncread("radiation.nc", "rad")

--- a/examples/low.jl
+++ b/examples/low.jl
@@ -38,37 +38,35 @@ radvar = NcVar("rad", [londim, latdim, timdim]; atts=varatts, t=Float32)
 # Now we can finally create the netcdf-file and get a file handler in return:
 
 isfile("radiation2.nc") && rm("radiation2.nc")
-nc = NetCDF.create("radiation2.nc", radvar)
+NetCDF.create("radiation2.nc", radvar) do nc
 
-# Writing data to the file is done using putvar
+  # Writing data to the file is done using putvar
 
-NetCDF.putvar(nc, "rad", rad)
+  NetCDF.putvar(nc, "rad", rad)
 
-# And we close the file
-
-NetCDF.close(nc)
+end
 
 # We open a file for reading:
 
-nc = NetCDF.open("radiation2.nc")
+NetCDF.open("radiation2.nc") do nc
 
-# we now have an NcFile object that can be browsed
+  # we now have an NcFile object that can be browsed
 
-println("Names of the NcFile fields: \n", fieldnames(typeof(nc)))
+  println("Names of the NcFile fields: \n", fieldnames(typeof(nc)))
 
-println("Attributes of the variable rad: ", nc.vars["rad"].atts)
+  println("Attributes of the variable rad: ", nc.vars["rad"].atts)
 
-# we read the whole variable:
+  # we read the whole variable:
 
-x = NetCDF.readvar(nc, "rad", start=[1, 1, 1], count=[-1, -1, -1])
-println("Successfully read an array of size ", size(x))
+  x = NetCDF.readvar(nc, "rad", start=[1, 1, 1], count=[-1, -1, -1])
+  println("Successfully read an array of size ", size(x))
 
-# Additional
-# Reading parts of a file, for example reading only time steps 5 and 6 can be done with:
+  # Additional
+  # Reading parts of a file, for example reading only time steps 5 and 6 can be done with:
 
-x = NetCDF.readvar(nc, "rad", start=[1,1,5], count=[-1,-1,2])
-println("Successfully read an array of size ", size(x))
+  x = NetCDF.readvar(nc, "rad", start=[1,1,5], count=[-1,-1,2])
+  println("Successfully read an array of size ", size(x))
 
 #here the first array [1,1,5] gives the starting position for reading while the second array [1,1,2] gives the number of blocks to be read along each dimension.
 # If the count is set to -1 the whole dimension is read.
-NetCDF.close(nc)
+end

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -16,6 +16,7 @@ export NcDim,NcVar,NcFile,ncread,ncread!,ncwrite,nccreate,ncinfo,ncclose,ncputat
 
 @deprecate ncclose() nothing
 @deprecate ncsync() nothing
+@deprecate ncclose(::AbstractString) nothing
 
 NC_VERBOSE = false
 #Some constants
@@ -546,16 +547,6 @@ Synchronizes the changes made to the file and writes changes to the disk.
 """
 function sync(nc::NcFile)
     nc_sync(nc.ncid)
-end
-
-#Function to close netcdf files
-"""
-    ncclose(filename::String)
-
-Closes the file and writes changes to the disk. If argument is omitted, all open files are closed.
-"""
-function ncclose(fil::AbstractString)
-    throw(DeprecationWarning("ncclose(::String) is deprecated, use NetCDF.close(nc::NcFile) to close a file."))
 end
 
 function setcompression(v::NcVar,mode)

--- a/test/array-like.jl
+++ b/test/array-like.jl
@@ -1,14 +1,14 @@
-ncclose()
-v1 = NetCDF.open(fn1, "v1", mode=NC_WRITE)
-@test isa(v1, NetCDF.NcVar{Float64, 3, 6})
-@test v1[1,1,1] == x1[1,1,1]
+NetCDF.open(fn1, "v1", mode=NC_WRITE) do v1
+  @test isa(v1, NetCDF.NcVar{Float64, 3, 6})
+  @test v1[1,1,1] == x1[1,1,1]
 
-@test dropdims(v1[2,:,2],dims=(1,3)) == x1[2,:,2]
+  @test dropdims(v1[2,:,2],dims=(1,3)) == x1[2,:,2]
 
-@test dropdims(v1[:,3,1],dims=(2,3)) == x1[:,3,1]
-inds = bitrand(size(x1))
-@test v1[inds] == x1[inds]
+  @test dropdims(v1[:,3,1],dims=(2,3)) == x1[:,3,1]
+  inds = bitrand(size(x1))
+  @test v1[inds] == x1[inds]
 
-xnew = rand(Float64,size(x1))
-v1[:,:,:] = xnew
-@test v1 == xnew
+  xnew = rand(Float64,size(x1))
+  v1[:,:,:] = xnew
+  @test v1 == xnew
+end

--- a/test/chunks.jl
+++ b/test/chunks.jl
@@ -2,8 +2,6 @@
 cfn1 = tempname2()
 nccreate(cfn1, "v1", "d1", 10, "d2", 20, chunksize=(5,5))
 ncwrite(rand(10, 20), cfn1, "v1")
-ncclose()
 v = NetCDF.open(cfn1, "v1")
 @test v.chunksize == (5, 5)
 v = 0
-ncclose()

--- a/test/high.jl
+++ b/test/high.jl
@@ -75,14 +75,7 @@ nccreate(fn5, "x5_1", "dim1", collect(Int32, 1:4), Dict("units"=>"m"))
 nccreate(fn5, "x5_2", "dim2", collect(Float32, 1:4), Dict("units"=>"m"))
 @test typeof(ncread(fn5, "dim1")) == Array{Int32, 1}
 @test typeof(ncread(fn5, "dim2")) == Array{Float32, 1}
-ncclose()
 
 # Open file by reading and create new variable
 ncread(fn4, "myvar2")
 nccreate(fn4, "myvar3", "time", Inf)
-
-ncclose()
-nci = ncinfo(fn1);
-@test show(nci) === nothing
-@test all(isequal.(nci.vars["v1"].atts["Additional String array attribute"], string.("string attribute ",1:20)))
-ncclose()


### PR DESCRIPTION
As discussed in #94 this removes the currentNcFiles cache and leaves the user with the following possibilities to handle the opening/closing of files:

1. Through the high-level interface (`ncread`, `ncwrite`, `ncputatt` and friends) which will open and close the file for every operation
2. Through the new open-do and create-do syntax of the intermediate interface (similar to regular files or ArchGDAL) where you can do something like:
````julia
x  = open("myfile.nc","myvar") do v
  v[:,:,1]
end
````
3. As before by manually pairing every `NetCDF.open` or `NetCDF.create` with a corresponding `NetCDF.close`

Maybe @visr could you have a look while I am updating the docs?