### PR TITLE
format all code

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,10 @@ using BinDeps
 import CondaBinDeps
 
 @BinDeps.setup
-libnetcdf = library_dependency("libnetcdf", aliases = ["libnetcdf4","libnetcdf-7","netcdf"])
+libnetcdf = library_dependency(
+    "libnetcdf",
+    aliases = ["libnetcdf4", "libnetcdf-7", "netcdf"],
+)
 
 #CondaBinDeps.Conda.add_channel("conda-forge")
 provides(CondaBinDeps.Manager, "libnetcdf", libnetcdf)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,16 +6,9 @@ makedocs(
     sitename = "NetCDF.jl",
     authors = "Fabian Gans and contributors",
     pages = [
-      "Home" => "index.md",
-      "Manual" => [
-        "quickstart.md",
-        "highlevel.md",
-        "intermediate.md",
-        "strings.md"
-      ]
-    ]
+        "Home" => "index.md",
+        "Manual" => ["quickstart.md", "highlevel.md", "intermediate.md", "strings.md"],
+    ],
 )
 
-deploydocs(
-    repo = "github.com/JuliaGeo/NetCDF.jl.git"
-)
+deploydocs(repo = "github.com/JuliaGeo/NetCDF.jl.git")

--- a/examples/high.jl
+++ b/examples/high.jl
@@ -13,23 +13,31 @@ day = 1
 tim = collect(0:23)
 
 # Create radiation array
-rad = Float64[g_pot(x2,x1,day,x3) for x1=lon, x2=lat, x3=tim]
+rad = Float64[g_pot(x2, x1, day, x3) for x1 in lon, x2 in lat, x3 in tim]
 
 # Define some attributes of the variable (optionlal)
-varatts = Dict("longname" => "Radiation at the top of the atmosphere",
-               "units"    => "W/m^2")
-lonatts = Dict("longname" => "Longitude",
-               "units"    => "degrees east")
-latatts = Dict("longname" => "Latitude",
-               "units"    => "degrees north")
-timatts = Dict("longname" => "Time",
-               "units"    => "hours since 01-01-2000 00:00:00")
+varatts = Dict("longname" => "Radiation at the top of the atmosphere", "units" => "W/m^2")
+lonatts = Dict("longname" => "Longitude", "units" => "degrees east")
+latatts = Dict("longname" => "Latitude", "units" => "degrees north")
+timatts = Dict("longname" => "Time", "units" => "hours since 01-01-2000 00:00:00")
 
 # Now we create the file radiation.nc and call the variable rad, define also the dimensions the variables depends on
 
 isfile("radiation.nc") && rm("radiation.nc")
-nccreate("radiation.nc", "rad", "lon", lon, lonatts, "lat", lat, latatts,
-    "time", tim, timatts, atts=varatts)
+nccreate(
+    "radiation.nc",
+    "rad",
+    "lon",
+    lon,
+    lonatts,
+    "lat",
+    lat,
+    latatts,
+    "time",
+    tim,
+    timatts,
+    atts = varatts,
+)
 
 # Now we can write values to the file
 
@@ -43,7 +51,7 @@ println("Successfully read an array of size ", size(x))
 # Additional
 # Reading parts of a file, for example reading only time steps 5 and 6 can be done with:
 
-x = ncread("radiation.nc", "rad", [1,1,5], [-1,-1,2])
+x = ncread("radiation.nc", "rad", [1, 1, 5], [-1, -1, 2])
 println("Successfully read an array of size ", size(x))
 
 # here the first array [1,1,5] gives the starting position for reading while the second array [1,1,2] gives the number of blocks to be read along each dimension.

--- a/examples/low.jl
+++ b/examples/low.jl
@@ -13,60 +13,46 @@ day = 1
 tim = collect(0:23)
 
 # Create radiation array
-rad = Float64[g_pot(x2,x1,day,x3) for x1=lon, x2=lat, x3=tim]
+rad = Float64[g_pot(x2, x1, day, x3) for x1 in lon, x2 in lat, x3 in tim]
 
 # Define some attributes of the variable (optionlal)
-varatts = Dict("longname" => "Radiation at the top of the atmosphere",
-               "units"    => "W/m^2")
-lonatts = Dict("longname" => "Longitude",
-               "units"    => "degrees east")
-latatts = Dict("longname" => "Latitude",
-               "units"    => "degrees north")
-timatts = Dict("longname" => "Time",
-               "units"    => "hours since 01-01-2000 00:00:00")
+varatts = Dict("longname" => "Radiation at the top of the atmosphere", "units" => "W/m^2")
+lonatts = Dict("longname" => "Longitude", "units" => "degrees east")
+latatts = Dict("longname" => "Latitude", "units" => "degrees north")
+timatts = Dict("longname" => "Time", "units" => "hours since 01-01-2000 00:00:00")
 
-#Here we start by defining the dimensions. This is done by creating NcDim objects:
+# Here we start by defining the dimensions. This is done by creating NcDim objects:
 
 latdim = NcDim("lat", lat, latatts)
 londim = NcDim("lon", lon, lonatts)
 timdim = NcDim("time", tim, timatts)
 
 # Then we create an NcVar object, the data type is defined by the corresponding julia type:
-
-radvar = NcVar("rad", [londim, latdim, timdim]; atts=varatts, t=Float32)
+radvar = NcVar("rad", [londim, latdim, timdim]; atts = varatts, t = Float32)
 
 # Now we can finally create the netcdf-file and get a file handler in return:
-
 isfile("radiation2.nc") && rm("radiation2.nc")
 NetCDF.create("radiation2.nc", radvar) do nc
-
-  # Writing data to the file is done using putvar
-
-  NetCDF.putvar(nc, "rad", rad)
-
+      # Writing data to the file is done using putvar
+    NetCDF.putvar(nc, "rad", rad)
 end
 
 # We open a file for reading:
-
 NetCDF.open("radiation2.nc") do nc
+    # we now have an NcFile object that can be browsed
+    println("Names of the NcFile fields: \n", fieldnames(typeof(nc)))
+    println("Attributes of the variable rad: ", nc.vars["rad"].atts)
 
-  # we now have an NcFile object that can be browsed
+    # we read the whole variable:
+    x = NetCDF.readvar(nc, "rad", start = [1, 1, 1], count = [-1, -1, -1])
+    println("Successfully read an array of size ", size(x))
 
-  println("Names of the NcFile fields: \n", fieldnames(typeof(nc)))
+    # Additional
+    # Reading parts of a file, for example reading only time steps 5 and 6 can be done with:
+    x = NetCDF.readvar(nc, "rad", start = [1, 1, 5], count = [-1, -1, 2])
+    println("Successfully read an array of size ", size(x))
 
-  println("Attributes of the variable rad: ", nc.vars["rad"].atts)
-
-  # we read the whole variable:
-
-  x = NetCDF.readvar(nc, "rad", start=[1, 1, 1], count=[-1, -1, -1])
-  println("Successfully read an array of size ", size(x))
-
-  # Additional
-  # Reading parts of a file, for example reading only time steps 5 and 6 can be done with:
-
-  x = NetCDF.readvar(nc, "rad", start=[1,1,5], count=[-1,-1,2])
-  println("Successfully read an array of size ", size(x))
-
-#here the first array [1,1,5] gives the starting position for reading while the second array [1,1,2] gives the number of blocks to be read along each dimension.
-# If the count is set to -1 the whole dimension is read.
+    # here the first array [1,1,5] gives the starting position for reading
+    # while the second array [1,1,2] gives the number of blocks to be read along each dimension.
+    # If the count is set to -1 the whole dimension is read.
 end

--- a/examples/toa.jl
+++ b/examples/toa.jl
@@ -5,8 +5,8 @@ function g_pot(latitude, longitude, d_, t_)
     localstandardtime = t_
     tthet = 2π * (d_ - 1.0) / 365.0
 
-    eqoftime = (0.000075 + 0.001868 * cos(tthet) - 0.032077 * sin(tthet) - 0.014615 * cos(2*tthet) -
-        0.040849 * sin(2 * tthet)) * 229.18
+    eqoftime = (0.000075 + 0.001868 * cos(tthet) - 0.032077 * sin(tthet) -
+                0.014615 * cos(2 * tthet) - 0.040849 * sin(2 * tthet)) * 229.18
 
     localapparentsolartime = localstandardtime + eqoftime / 60 + longitude / 15
     signedLAS = 12 - localapparentsolartime
@@ -14,20 +14,21 @@ function g_pot(latitude, longitude, d_, t_)
     signedLAS = abs(signedLAS)
     omega = -15 * signedLAS
 
-    decl_rad = 0.006918 - 0.399912 * cos(tthet) + 0.070257 * sin(tthet) - 0.006758 * cos(2*tthet) +
-        0.000907 * sin(2 * tthet) - 0.002697 * cos(3 * tthet) + 0.00148 * sin(3 * tthet)
+    decl_rad = 0.006918 - 0.399912 * cos(tthet) + 0.070257 * sin(tthet) -
+               0.006758 * cos(2 * tthet) + 0.000907 * sin(2 * tthet) -
+               0.002697 * cos(3 * tthet) + 0.00148 * sin(3 * tthet)
     lat_rad = deg2rad(latitude)
     long_rad = deg2rad(longitude)
 
-    theta_rad = acos(sin(decl_rad) * sin(lat_rad) + cos(decl_rad) * cos(lat_rad) *
-        cos(omega * π / 180.0))
+    theta_rad = acos(sin(decl_rad) * sin(lat_rad) +
+                     cos(decl_rad) * cos(lat_rad) * cos(omega * π / 180.0))
 
     dt = d_ + t_ / 24
 
     solarconst = 1376
 
     Rpot = solarconst * (1.00011 + 0.034221 * cos(tthet) + 0.00128 * sin(tthet) +
-        0.000719 * cos(2 * tthet) + 0.000077 * sin(2 * tthet))
+            0.000719 * cos(2 * tthet) + 0.000077 * sin(2 * tthet))
 
     Rpot_h = Rpot * cos(theta_rad)
     Rpot_h = cos(theta_rad) < 0.0 ? 0.0 : Rpot_h

--- a/gen/wrap.jl
+++ b/gen/wrap.jl
@@ -18,10 +18,12 @@ srcdir = joinpath(workdir, "../src")
 headerpath = ["/home/martijn/src/netcdf-4.4.1/include/netcdf.h"]
 includedirs = ["/home/martijn/src/netcdf-4.4.1/include"]
 
-context=wrap_c.init(headers=headerpath,
-                    output_dir=workdir,
-                    common_file="common.jl",
-                    clang_includes=includedirs,
-                    header_library=x->"libnetcdf")
+context = wrap_c.init(
+    headers = headerpath,
+    output_dir = workdir,
+    common_file = "common.jl",
+    clang_includes = includedirs,
+    header_library = x -> "libnetcdf",
+)
 
 run(context)

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module NetCDF
 
 using Formatting
@@ -9,10 +7,34 @@ include("netcdf_c.jl")
 
 import Base.show
 
-export NcDim,NcVar,NcFile,ncread,ncread!,ncwrite,nccreate,ncinfo,ncclose,ncputatt,
-    NC_BYTE,NC_SHORT,NC_INT,NC_FLOAT,NC_DOUBLE,NC_STRING,ncgetatt,NC_NOWRITE,NC_WRITE,NC_CHAR,
-    NC_CLOBBER,NC_NOCLOBBER,NC_CLASSIC_MODEL,NC_64BIT_OFFSET,NC_NETCDF4,NC_UNLIMITED,
-    nc_char2string, nc_string2char
+export NcDim,
+       NcVar,
+       NcFile,
+       ncread,
+       ncread!,
+       ncwrite,
+       nccreate,
+       ncinfo,
+       ncclose,
+       ncputatt,
+       NC_BYTE,
+       NC_SHORT,
+       NC_INT,
+       NC_FLOAT,
+       NC_DOUBLE,
+       NC_STRING,
+       ncgetatt,
+       NC_NOWRITE,
+       NC_WRITE,
+       NC_CHAR,
+       NC_CLOBBER,
+       NC_NOCLOBBER,
+       NC_CLASSIC_MODEL,
+       NC_64BIT_OFFSET,
+       NC_NETCDF4,
+       NC_UNLIMITED,
+       nc_char2string,
+       nc_string2char
 
 @deprecate ncclose() nothing
 @deprecate ncsync() nothing
@@ -29,7 +51,7 @@ primitive type ASCIIChar <: AbstractChar 8 end
 ASCIIChar(c::UInt8) = reinterpret(ASCIIChar, c)
 ASCIIChar(c::UInt32) = ASCIIChar(UInt8(c))
 Base.codepoint(c::ASCIIChar) = reinterpret(UInt8, c)
-Base.zero(::Type{ASCIIChar})=ASCIIChar(0)
+Base.zero(::Type{ASCIIChar}) = ASCIIChar(0)
 
 global const nctype2jltype = Dict(
     NC_BYTE => Int8,
@@ -43,25 +65,30 @@ global const nctype2jltype = Dict(
     NC_FLOAT => Float32,
     NC_DOUBLE => Float64,
     NC_CHAR => ASCIIChar,
-    NC_STRING => String)
+    NC_STRING => String,
+)
 
 global const nctype2string = Dict(
-  NC_BYTE => "BYTE",
-  NC_UBYTE => "UBYTE",
-  NC_SHORT => "SHORT",
-  NC_USHORT => "USHORT",
-  NC_INT => "INT",
-  NC_UINT => "UINT",
-  NC_INT64 => "INT64",
-  NC_UINT64 => "UINT64",
-  NC_FLOAT => "FLOAT",
-  NC_DOUBLE => "DOUBLE",
-  NC_STRING => "STRING",
-  NC_CHAR => "CHAR")
+    NC_BYTE => "BYTE",
+    NC_UBYTE => "UBYTE",
+    NC_SHORT => "SHORT",
+    NC_USHORT => "USHORT",
+    NC_INT => "INT",
+    NC_UINT => "UINT",
+    NC_INT64 => "INT64",
+    NC_UINT64 => "UINT64",
+    NC_FLOAT => "FLOAT",
+    NC_DOUBLE => "DOUBLE",
+    NC_STRING => "STRING",
+    NC_CHAR => "CHAR",
+)
 
 
 function jl2nc(t::DataType)
-    popfirst!(collect(keys(nctype2jltype))[findall(e->(t <: e), collect(values(nctype2jltype)))])
+    popfirst!(collect(keys(nctype2jltype))[findall(
+        e -> (t <: e),
+        collect(values(nctype2jltype)),
+    )])
 end
 jl2nc(t::Type{UInt8}) = NC_UBYTE
 
@@ -77,14 +104,14 @@ getNCType(t::Int) = Int(t)
 Represents a NetCDF dimension of name `name` optionally holding the dimension values.
 """
 mutable struct NcDim
-  ncid::Int32
-  dimid::Int32
-  varid::Int32
-  name::String
-  dimlen::UInt
-  vals::AbstractArray
-  atts::Dict
-  unlim::Bool
+    ncid::Int32
+    dimid::Int32
+    varid::Int32
+    name::String
+    dimlen::UInt
+    vals::AbstractArray
+    atts::Dict
+    unlim::Bool
 end
 
 
@@ -99,9 +126,17 @@ Creates a NetCDF dimension object named `name` with length `dimlength` in memory
 * `atts` a Dict of attributes associated to the dimension variable
 * `unlimited` is this the record dimension, defaults to `false`
 """
-function NcDim(name::AbstractString,dimlength::Integer;values::Union{AbstractArray,Number}=[],atts::Dict=Dict{Any,Any}(),unlimited=false)
-    length(values) > 0 && length(values) != dimlength && error("Dimension value vector must have the same length as dimlength!")
-    NcDim(-1,-1,-1,string(name),dimlength,collect(values),atts,unlimited)
+function NcDim(
+    name::AbstractString,
+    dimlength::Integer;
+    values::Union{AbstractArray,Number} = [],
+    atts::Dict = Dict{Any,Any}(),
+    unlimited = false,
+)
+    length(values) > 0 &&
+    length(values) != dimlength &&
+    error("Dimension value vector must have the same length as dimlength!")
+    NcDim(-1, -1, -1, string(name), dimlength, collect(values), atts, unlimited)
 end
 
 
@@ -115,10 +150,14 @@ Creates a NetCDF dimension object named `name` and associated `values` in memory
 * `atts` a Dict of attributes associated to the dimension variable
 * `unlimited` is this the record dimension, defaults to `false`
 """
-NcDim(name::AbstractString,values::AbstractArray;atts::Dict=Dict{Any,Any}(),unlimited=false) =
-    NcDim(name,length(values),values=values,atts=atts,unlimited=unlimited)
-NcDim(name::AbstractString,values::AbstractArray,atts::Dict;unlimited=false) =
-    NcDim(name,length(values),values=values,atts=atts,unlimited=unlimited)
+NcDim(
+    name::AbstractString,
+    values::AbstractArray;
+    atts::Dict = Dict{Any,Any}(),
+    unlimited = false,
+) = NcDim(name, length(values), values = values, atts = atts, unlimited = unlimited)
+NcDim(name::AbstractString, values::AbstractArray, atts::Dict; unlimited = false) =
+    NcDim(name, length(values), values = values, atts = atts, unlimited = unlimited)
 
 
 """
@@ -143,8 +182,32 @@ mutable struct NcVar{T,N,M} <: AbstractArray{T,N}
     chunksize::NTuple{N,Int32}
 end
 
-Base.convert(::Type{NcVar{T,N,M}},v::NcVar{S,N,M}) where {S,T,N,M}=NcVar{T,N,M}(v.ncid,v.varid,v.ndim,v.natts,v.nctype,v.name,v.dimids,v.dim,v.atts,v.compress,v.chunksize)
-Base.convert(::Type{NcVar{T}},v::NcVar{S,N,M}) where {S,T,N,M}=NcVar{T,N,M}(v.ncid,v.varid,v.ndim,v.natts,v.nctype,v.name,v.dimids,v.dim,v.atts,v.compress,v.chunksize)
+Base.convert(::Type{NcVar{T,N,M}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
+    v.ncid,
+    v.varid,
+    v.ndim,
+    v.natts,
+    v.nctype,
+    v.name,
+    v.dimids,
+    v.dim,
+    v.atts,
+    v.compress,
+    v.chunksize,
+)
+Base.convert(::Type{NcVar{T}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
+    v.ncid,
+    v.varid,
+    v.ndim,
+    v.natts,
+    v.nctype,
+    v.name,
+    v.dimids,
+    v.dim,
+    v.atts,
+    v.compress,
+    v.chunksize,
+)
 
 """
     NcVar(name::AbstractString,dimin::Union{NcDim,Array{NcDim,1}}
@@ -158,35 +221,84 @@ list of NetCDF dimensions specified by `dimin`.
 * `t` either a Julia type, (one of `Int16`, `Int32`, `Float32`, `Float64`, `String`) or a NetCDF data type (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`, `NC_CHAR`, `NC_STRING`) determines the data type of the variable. Defaults to -1
 * `compress` Integer which sets the compression level of the variable for NetCDF4 files. Defaults to -1 (no compression). Compression levels of 1..9 are valid
 """
-function NcVar(name::AbstractString,dimin::Union{NcDim,Array{NcDim,1}};atts::Dict=Dict{Any,Any}(),t::Union{DataType,Integer}=Float64,compress::Integer=-1,chunksize::Tuple=ntuple(i->zero(Int32),isa(dimin,NcDim) ? 1 : length(dimin)))
-    dim = isa(dimin,NcDim) ? NcDim[dimin] : dimin
-    chunksize = map(Int32,chunksize)
-    return NcVar{getJLType(t),length(dim),getNCType(t)}(Int32(-1),Int32(-1),Int32(length(dim)),Int32(length(atts)), getNCType(t),name,fill(Int32(-1),length(dim)),dim,atts,Int32(compress),chunksize)
+function NcVar(
+    name::AbstractString,
+    dimin::Union{NcDim,Array{NcDim,1}};
+    atts::Dict = Dict{Any,Any}(),
+    t::Union{DataType,Integer} = Float64,
+    compress::Integer = -1,
+    chunksize::Tuple = ntuple(i -> zero(Int32), isa(dimin, NcDim) ? 1 : length(dimin)),
+)
+    dim = isa(dimin, NcDim) ? NcDim[dimin] : dimin
+    chunksize = map(Int32, chunksize)
+    return NcVar{getJLType(t),length(dim),getNCType(t)}(
+        Int32(-1),
+        Int32(-1),
+        Int32(length(dim)),
+        Int32(length(atts)),
+        getNCType(t),
+        name,
+        fill(Int32(-1), length(dim)),
+        dim,
+        atts,
+        Int32(compress),
+        chunksize,
+    )
 end
 
 #Array methods
 @generated function Base.size(a::NcVar{T,N}) where {T,N}
-    :(@ntuple($N,i->Int(a.dim[i].dimlen)))
+    :(@ntuple($N, i -> Int(a.dim[i].dimlen)))
 end
-const IndR  = Union{Integer,UnitRange,Colon}
+const IndR = Union{Integer,UnitRange,Colon}
 const ArNum = Union{AbstractArray,Number}
 
 IndexStyle(::NcVar) = IndexCartesian()
 Base.getindex(v::NcVar{T,0}) where {T} = readvar(v)
-Base.getindex(v::NcVar{T,1},i1::IndR) where {T} = readvar(v,i1)
-Base.getindex(v::NcVar{T,2},i1::IndR,i2::IndR) where {T} = readvar(v,i1,i2)
-Base.getindex(v::NcVar{T,3},i1::IndR,i2::IndR,i3::IndR) where {T} = readvar(v,i1,i2,i3)
-Base.getindex(v::NcVar{T,4},i1::IndR,i2::IndR,i3::IndR,i4::IndR) where {T} = readvar(v,i1,i2,i3,i4)
-Base.getindex(v::NcVar{T,5},i1::IndR,i2::IndR,i3::IndR,i4::IndR,i5::IndR) where {T} = readvar(v,i1,i2,i3,i4,i5)
-Base.getindex(v::NcVar{T,6},i1::IndR,i2::IndR,i3::IndR,i4::IndR,i5::IndR,i6::IndR) where {T} = readvar(v,i1,i2,i3,i4,i5,i6)
+Base.getindex(v::NcVar{T,1}, i1::IndR) where {T} = readvar(v, i1)
+Base.getindex(v::NcVar{T,2}, i1::IndR, i2::IndR) where {T} = readvar(v, i1, i2)
+Base.getindex(v::NcVar{T,3}, i1::IndR, i2::IndR, i3::IndR) where {T} =
+    readvar(v, i1, i2, i3)
+Base.getindex(v::NcVar{T,4}, i1::IndR, i2::IndR, i3::IndR, i4::IndR) where {T} =
+    readvar(v, i1, i2, i3, i4)
+Base.getindex(v::NcVar{T,5}, i1::IndR, i2::IndR, i3::IndR, i4::IndR, i5::IndR) where {T} =
+    readvar(v, i1, i2, i3, i4, i5)
+Base.getindex(
+    v::NcVar{T,6},
+    i1::IndR,
+    i2::IndR,
+    i3::IndR,
+    i4::IndR,
+    i5::IndR,
+    i6::IndR,
+) where {T} = readvar(v, i1, i2, i3, i4, i5, i6)
 
-Base.setindex!(v::NcVar{T,0},x::ArNum) where {T} = putvar(v,x)
-Base.setindex!(v::NcVar{T,1},x::ArNum,i1::IndR) where {T} = putvar(v,x,i1)
-Base.setindex!(v::NcVar{T,2},x::ArNum,i1::IndR,i2::IndR) where {T} = putvar(v,x,i1,i2)
-Base.setindex!(v::NcVar{T,3},x::ArNum,i1::IndR,i2::IndR,i3::IndR) where {T} = putvar(v,x,i1,i2,i3)
-Base.setindex!(v::NcVar{T,4},x::ArNum,i1::IndR,i2::IndR,i3::IndR,i4::IndR) where {T} = putvar(v,x,i1,i2,i3,i4)
-Base.setindex!(v::NcVar{T,5},x::ArNum,i1::IndR,i2::IndR,i3::IndR,i4::IndR,i5::IndR) where {T} = putvar(v,x,i1,i2,i3,i4,i5)
-Base.setindex!(v::NcVar{T,6},x::ArNum,i1::IndR,i2::IndR,i3::IndR,i4::IndR,i5::IndR,i6::IndR) where {T} = putvar(v,x,i1,i2,i3,i4,i5,i6)
+Base.setindex!(v::NcVar{T,0}, x::ArNum) where {T} = putvar(v, x)
+Base.setindex!(v::NcVar{T,1}, x::ArNum, i1::IndR) where {T} = putvar(v, x, i1)
+Base.setindex!(v::NcVar{T,2}, x::ArNum, i1::IndR, i2::IndR) where {T} = putvar(v, x, i1, i2)
+Base.setindex!(v::NcVar{T,3}, x::ArNum, i1::IndR, i2::IndR, i3::IndR) where {T} =
+    putvar(v, x, i1, i2, i3)
+Base.setindex!(v::NcVar{T,4}, x::ArNum, i1::IndR, i2::IndR, i3::IndR, i4::IndR) where {T} =
+    putvar(v, x, i1, i2, i3, i4)
+Base.setindex!(
+    v::NcVar{T,5},
+    x::ArNum,
+    i1::IndR,
+    i2::IndR,
+    i3::IndR,
+    i4::IndR,
+    i5::IndR,
+) where {T} = putvar(v, x, i1, i2, i3, i4, i5)
+Base.setindex!(
+    v::NcVar{T,6},
+    x::ArNum,
+    i1::IndR,
+    i2::IndR,
+    i3::IndR,
+    i4::IndR,
+    i5::IndR,
+    i6::IndR,
+) where {T} = putvar(v, x, i1, i2, i3, i4, i5, i6)
 
 
 """
@@ -208,13 +320,19 @@ mutable struct NcFile
     in_def_mode::Bool
 end
 #Define getindex method to retrieve a variable
-Base.getindex(nc::NcFile,i::AbstractString) = haskey(nc.vars,i) ? nc.vars[i] : error("NetCDF file $(nc.name) does not have a variable named $(i)")
+Base.getindex(nc::NcFile, i::AbstractString) = haskey(nc.vars, i) ? nc.vars[i] :
+error("NetCDF file $(nc.name) does not have a variable named $(i)")
 
 include("netcdf_helpers.jl")
 
 
-readvar!(nc::NcFile, varname::AbstractString, retvalsa::AbstractArray;start::Vector=defaultstart(nc[varname]),count::Vector=defaultcount(nc[varname])) =
-    readvar!(nc[varname],retvalsa,start=start,count=count)
+readvar!(
+    nc::NcFile,
+    varname::AbstractString,
+    retvalsa::AbstractArray;
+    start::Vector = defaultstart(nc[varname]),
+    count::Vector = defaultcount(nc[varname]),
+) = readvar!(nc[varname], retvalsa, start = start, count = count)
 
 
 """
@@ -236,9 +354,15 @@ Assume `v` is a NetCDF variable with dimensions (3,3,10).
 
 This reads all values from the first and last dimension and only the second value from the second dimension.
 """
-function readvar!(v::NcVar, retvalsa::AbstractArray;start::Vector=defaultstart(v),count::Vector=defaultcount(v))
+function readvar!(
+    v::NcVar,
+    retvalsa::AbstractArray;
+    start::Vector = defaultstart(v),
+    count::Vector = defaultcount(v),
+)
 
-    isa(retvalsa,Array) || Base.iscontiguous(retvalsa) || error("Can only read into contiguous pieces of memory")
+    isa(retvalsa, Array) ||
+    Base.iscontiguous(retvalsa) || error("Can only read into contiguous pieces of memory")
 
     length(start) == v.ndim || error("Length of start ($(length(start))) must equal the number of variable dimensions ($(v.ndim))")
     length(count) == v.ndim || error("Length of start ($(length(count))) must equal the number of variable dimensions ($(v.ndim))")
@@ -253,8 +377,12 @@ function readvar!(v::NcVar, retvalsa::AbstractArray;start::Vector=defaultstart(v
 end
 
 
-readvar(nc::NcFile, varname::AbstractString;start::Vector=defaultstart(nc[varname]),count::Vector=defaultcount(nc[varname])) =
-    readvar(nc[varname],start=start,count=count)
+readvar(
+    nc::NcFile,
+    varname::AbstractString;
+    start::Vector = defaultstart(nc[varname]),
+    count::Vector = defaultcount(nc[varname]),
+) = readvar(nc[varname], start = start, count = count)
 
 """
     NetCDF.readvar(v::NcVar;start::Vector=ones(UInt,ndims(d)),count::Vector=size(d))
@@ -274,10 +402,14 @@ Assume `v` is a NetCDF variable with dimensions (3,3,10).
 
 This reads all values from the first and last dimension and only the second value from the second dimension.
 """
-function readvar(v::NcVar{T,N};start::Vector=defaultstart(v),count::Vector=defaultcount(v)) where {T,N}
-    s = [count[i]==-1 ? size(v,i)-start[i]+1 : count[i] for i=1:length(count)]
-    retvalsa = Array{T}(undef,s...)
-    readvar!(v, retvalsa, start=start, count=count)
+function readvar(
+    v::NcVar{T,N};
+    start::Vector = defaultstart(v),
+    count::Vector = defaultcount(v),
+) where {T,N}
+    s = [count[i] == -1 ? size(v, i) - start[i] + 1 : count[i] for i = 1:length(count)]
+    retvalsa = Array{T}(undef, s...)
+    readvar!(v, retvalsa, start = start, count = count)
     return retvalsa
 end
 
@@ -286,9 +418,9 @@ end
 
 Reads data from a NetCDF file with array-style indexing. `Integer`s and `UnitRange`s and `Colon`s are valid indices for each dimension.
 """
-function readvar(v::NcVar{T,N},I::IndR...) where {T,N}
-    count=ntuple(i->counti(I[i],v.dim[i].dimlen),length(I))
-    retvalsa = Array{T}(undef,count...)
+function readvar(v::NcVar{T,N}, I::IndR...) where {T,N}
+    count = ntuple(i -> counti(I[i], v.dim[i].dimlen), length(I))
+    retvalsa = Array{T}(undef, count...)
     readvar!(v, retvalsa, I...)
     return retvalsa
 end
@@ -296,29 +428,29 @@ end
 
 # Here are some functions for array-style indexing readvar
 #For single indices
-@generated function readvar(v::NcVar{T,N},I::Integer...) where {T,N}
-    N==length(I) || error("Dimension mismatch")
-    if N==0
-      quote
-        checkbounds(v,I...)
-        gstart[1]=0
-        nc_get_var1_x(v,gstart,T)::T
-      end
+@generated function readvar(v::NcVar{T,N}, I::Integer...) where {T,N}
+    N == length(I) || error("Dimension mismatch")
+    if N == 0
+        quote
+            checkbounds(v, I...)
+            gstart[1] = 0
+            nc_get_var1_x(v, gstart, T)::T
+        end
     else
-      quote
-        checkbounds(v,I...)
-        @nexprs $N i->gstart[v.ndim+1-i]=I[i]-1
-        nc_get_var1_x(v,gstart,T)::T
-      end
+        quote
+            checkbounds(v, I...)
+            @nexprs $N i -> gstart[v.ndim+1-i] = I[i] - 1
+            nc_get_var1_x(v, gstart, T)::T
+        end
     end
 end
 
-firsti(i::Integer,l::Integer) = i-1
-counti(i::Integer,l::Integer) = 1
-firsti(r::UnitRange,l::Integer) = first(r)-1
-counti(r::UnitRange,l::Integer) = length(r)
-firsti(r::Colon,l::Integer) = 0
-counti(r::Colon,l::Integer) = Int(l)
+firsti(i::Integer, l::Integer) = i - 1
+counti(i::Integer, l::Integer) = 1
+firsti(r::UnitRange, l::Integer) = first(r) - 1
+counti(r::UnitRange, l::Integer) = length(r)
+firsti(r::Colon, l::Integer) = 0
+counti(r::Colon, l::Integer) = Int(l)
 
 # For ranges
 """
@@ -326,75 +458,105 @@ counti(r::Colon,l::Integer) = Int(l)
 
 Reads data from a NetCDF file with array-style indexing and writes them to d. `Integer`s and `UnitRange`s and `Colon`s are valid indices for each dimension.
 """
-@generated function readvar!(v::NcVar{T,N}, retvalsa::AbstractArray,I::IndR...) where {T,N}
+@generated function readvar!(v::NcVar{T,N}, retvalsa::AbstractArray, I::IndR...) where {T,N}
 
     N == length(I) || error("Dimension mismatch")
 
     quote
         checkbounds(v, I...)
 
-        isa(retvalsa, Array) || Base.iscontiguous(retvalsa) || error("Can only read into contiguous pieces of memory")
+        isa(retvalsa, Array) ||
+        Base.iscontiguous(retvalsa) ||
+        error("Can only read into contiguous pieces of memory")
 
-        @nexprs $N i->gstart[v.ndim+1-i]=firsti(I[i],v.dim[i].dimlen)
-        @nexprs $N i->gcount[v.ndim+1-i]=counti(I[i],v.dim[i].dimlen)
-        p=1
-        @nexprs $N i->p=p*gcount[v.ndim+1-i]
-        length(retvalsa) != p && error(string("Size of output array ($(length(retvalsa))) does not equal number of elements to be read (",p,")!"))
-        nc_get_vara_x!(v,gstart,gcount,retvalsa)
+        @nexprs $N i -> gstart[v.ndim+1-i] = firsti(I[i], v.dim[i].dimlen)
+        @nexprs $N i -> gcount[v.ndim+1-i] = counti(I[i], v.dim[i].dimlen)
+        p = 1
+        @nexprs $N i -> p = p * gcount[v.ndim+1-i]
+        length(retvalsa) != p && error(string(
+            "Size of output array ($(length(retvalsa))) does not equal number of elements to be read (",
+            p,
+            ")!",
+        ))
+        nc_get_vara_x!(v, gstart, gcount, retvalsa)
         retvalsa
     end
 end
 
 
-for (t,ending,arname) in funext
+for (t, ending, arname) in funext
     fname = Symbol("nc_get_vara_$ending")
     fname1 = Symbol("nc_get_var1_$ending")
     arsym = Symbol(arname)
-    @eval nc_get_vara_x!(v::NcVar{$t},start::Vector{UInt},count::Vector{UInt},retvalsa::AbstractArray{$t})=$fname(v.ncid,v.varid,start,count,retvalsa)
-    @eval nc_get_var1_x(v::NcVar{$t},start::Vector{UInt},::Type{$t})=begin $fname1(v.ncid,v.varid,start,$(arsym)); $(arsym)[1] end
+    @eval nc_get_vara_x!(
+        v::NcVar{$t},
+        start::Vector{UInt},
+        count::Vector{UInt},
+        retvalsa::AbstractArray{$t},
+    ) = $fname(v.ncid, v.varid, start, count, retvalsa)
+    @eval nc_get_var1_x(v::NcVar{$t}, start::Vector{UInt}, ::Type{$t}) = begin
+        $fname1(v.ncid, v.varid, start, $(arsym))
+        $(arsym)[1]
+    end
 end
 
-nc_get_vara_x!(v::NcVar{ASCIIChar,N,NC_CHAR},start::Vector{UInt},count::Vector{UInt},retvalsa::AbstractArray{<:ASCIIChar}) where {N} =
-    nc_get_vara_text(v.ncid,v.varid,start,count,retvalsa)
-nc_get_var1_x!(v::NcVar{ASCIIChar,N,NC_CHAR},start::Vector{UInt},retvalsa::AbstractArray{<:ASCIIChar}) where {N} =
-    nc_get_var1_text(v.ncid,v.varid,start,retvalsa)
+nc_get_vara_x!(
+    v::NcVar{ASCIIChar,N,NC_CHAR},
+    start::Vector{UInt},
+    count::Vector{UInt},
+    retvalsa::AbstractArray{<:ASCIIChar},
+) where {N} = nc_get_vara_text(v.ncid, v.varid, start, count, retvalsa)
+nc_get_var1_x!(
+    v::NcVar{ASCIIChar,N,NC_CHAR},
+    start::Vector{UInt},
+    retvalsa::AbstractArray{<:ASCIIChar},
+) where {N} = nc_get_var1_text(v.ncid, v.varid, start, retvalsa)
 
-function nc_get_vara_x!(v::NcVar{String,N,NC_STRING},start::Vector{UInt},count::Vector{UInt},retvalsa::AbstractArray{<:String}) where N
-    @assert length(retvalsa)==prod(view(count,1:N))
-    retvalsa_c=fill(Ptr{UInt8}(0),length(retvalsa))
-    nc_get_vara_string(v.ncid,v.varid,start,count,retvalsa_c)
-    for i=1:length(retvalsa)
-        retvalsa[i]=unsafe_string(retvalsa_c[i])
+function nc_get_vara_x!(
+    v::NcVar{String,N,NC_STRING},
+    start::Vector{UInt},
+    count::Vector{UInt},
+    retvalsa::AbstractArray{<:String},
+) where {N}
+    @assert length(retvalsa) == prod(view(count, 1:N))
+    retvalsa_c = fill(Ptr{UInt8}(0), length(retvalsa))
+    nc_get_vara_string(v.ncid, v.varid, start, count, retvalsa_c)
+    for i = 1:length(retvalsa)
+        retvalsa[i] = unsafe_string(retvalsa_c[i])
     end
-    nc_free_string(length(retvalsa_c),retvalsa_c)
+    nc_free_string(length(retvalsa_c), retvalsa_c)
     retvalsa
 end
 
-function nc_get_var1_x(v::NcVar{String,N,NC_STRING},start::Vector{UInt},::Type{String}) where N
-    retvalsa_c=fill(Ptr{UInt8}(0),1)
-    nc_get_var1_string(v.ncid,v.varid,start,retvalsa_c)
-    retval=unsafe_string(retvalsa_c[1])
-    nc_free_string(1,retvalsa_c)
+function nc_get_var1_x(
+    v::NcVar{String,N,NC_STRING},
+    start::Vector{UInt},
+    ::Type{String},
+) where {N}
+    retvalsa_c = fill(Ptr{UInt8}(0), 1)
+    nc_get_var1_string(v.ncid, v.varid, start, retvalsa_c)
+    retval = unsafe_string(retvalsa_c[1])
+    nc_free_string(1, retvalsa_c)
     retval
 end
 
 
-function putatt(ncid::Integer,varid::Integer,atts::Dict)
+function putatt(ncid::Integer, varid::Integer, atts::Dict)
     for a in atts
-        name=a[1]
-        val=a[2]
-        nc_put_att(ncid,varid,name,val)
+        name = a[1]
+        val = a[2]
+        nc_put_att(ncid, varid, name, val)
     end
 end
 
 function putatt(nc::NcFile, atts::Dict)
     putatt(nc.ncid, NC_GLOBAL, atts)
-    merge!(nc.gatts, getatts(nc.ncid,NC_GLOBAL,collect(keys(atts))))
+    merge!(nc.gatts, getatts(nc.ncid, NC_GLOBAL, collect(keys(atts))))
 end
 
 function putatt(var::NcVar, atts::Dict)
     putatt(var.ncid, var.varid, atts)
-    merge!(var.atts, getatts(var.ncid,var.varid,collect(keys(atts))))
+    merge!(var.atts, getatts(var.ncid, var.varid, collect(keys(atts))))
 end
 
 """
@@ -404,16 +566,16 @@ Writes the attributes defined in `atts` to the variable `varname` in the NetCDF 
 `nc`. Existing attributes are overwritten. If varname is not a valid variable name,
 a global attribute will be written.
 """
-function putatt(nc::NcFile,varname::AbstractString,atts::Dict)
+function putatt(nc::NcFile, varname::AbstractString, atts::Dict)
     chdef = false
     if !nc.in_def_mode
         chdef = true
         nc_redef(nc.ncid)
     end
-    if haskey(nc.vars,varname)
-        putatt(nc.vars[varname],atts)
+    if haskey(nc.vars, varname)
+        putatt(nc.vars[varname], atts)
     else
-        putatt(nc,atts)
+        putatt(nc, atts)
     end
     chdef && nc_enddef(nc.ncid)
 end
@@ -425,20 +587,25 @@ Writes the attributes defined in `atts` to the variable `varname` for the given 
 `nc`. Existing attributes are overwritten. If varname is not a valid variable name,
 a global attribute will be written.
 """
-function ncputatt(ncs::AbstractString,varname::AbstractString,atts::Dict)
-    open(ncs,mode=NC_WRITE) do nc
-      if (nc.omode == NC_NOWRITE)
-        fil = nc.name
-        close(nc)
-        println("reopening file in WRITE mode")
-        open(fil, mode=NC_WRITE)
-      end
-      putatt(nc, varname, atts)
+function ncputatt(ncs::AbstractString, varname::AbstractString, atts::Dict)
+    open(ncs, mode = NC_WRITE) do nc
+        if (nc.omode == NC_NOWRITE)
+            fil = nc.name
+            close(nc)
+            println("reopening file in WRITE mode")
+            open(fil, mode = NC_WRITE)
+        end
+        putatt(nc, varname, atts)
     end
 end
 
-putvar(nc::NcFile,varname::AbstractString,vals::AbstractArray;start=ones(Int,length(size(vals))),count=[size(vals)...]) =
-    putvar(nc[varname], vals, start=start, count=count)
+putvar(
+    nc::NcFile,
+    varname::AbstractString,
+    vals::AbstractArray;
+    start = ones(Int, length(size(vals))),
+    count = [size(vals)...],
+) = putvar(nc[varname], vals, start = start, count = count)
 
 """
     NetCDF.putvar(v::NcVar,vals::Array;start::Vector=ones(Int,length(size(vals))),count::Vector=[size(vals)...])
@@ -452,9 +619,15 @@ with the same dimension as the variable in the NetCDF file.
 * `count` Vector of length `ndim(v)` setting the count of values to be read along each dimension. The value -1 is treated as a special case to read all values from this dimension
 
 """
-function putvar(v::NcVar,vals::AbstractArray;start::Vector=ones(Int,length(size(vals))),count::Vector=[size(vals)...])
-    isa(vals,Array) || Base.iscontiguous(vals) || error("Can only write from contiguous pieces of memory")
-    p=preparestartcount(start, count, v)
+function putvar(
+    v::NcVar,
+    vals::AbstractArray;
+    start::Vector = ones(Int, length(size(vals))),
+    count::Vector = [size(vals)...],
+)
+    isa(vals, Array) ||
+    Base.iscontiguous(vals) || error("Can only write from contiguous pieces of memory")
+    p = preparestartcount(start, count, v)
     nc_put_vara_x(v, gstart, gcount, vals)
 end
 
@@ -463,35 +636,44 @@ end
 
 Writes the value(s) `val` to the variable `v` while the indices are given in in an array-style indexing manner.
 """
-@generated function putvar(v::NcVar{T,N},val::Any,I::IndR...) where {T,N}
+@generated function putvar(v::NcVar{T,N}, val::Any, I::IndR...) where {T,N}
 
-    N==length(I) || error("Dimension mismatch")
+    N == length(I) || error("Dimension mismatch")
     quote
-        isa(val,Number) || isa(val,Array) || Base.iscontiguous(val) || error("Can only write from contiguous pieces of memory")
-        @nexprs $N i->gstart[v.ndim+1-i]=firsti(I[i],v.dim[i].dimlen)
-        @nexprs $N i->gcount[v.ndim+1-i]=counti(I[i],v.dim[i].dimlen)
+        isa(val, Number) ||
+        isa(val, Array) ||
+        Base.iscontiguous(val) || error("Can only write from contiguous pieces of memory")
+        @nexprs $N i -> gstart[v.ndim+1-i] = firsti(I[i], v.dim[i].dimlen)
+        @nexprs $N i -> gcount[v.ndim+1-i] = counti(I[i], v.dim[i].dimlen)
         checkboundsNC(v)
-        p=1
-        @nexprs $N i->p=p*gcount[v.ndim+1-i]
-        length(val) != p && error(string("Size of output array ($(length(retvalsa))) does not equal number of elements to be read (",p,")!"))
-        nc_put_vara_x(v,gstart,gcount,val)
+        p = 1
+        @nexprs $N i -> p = p * gcount[v.ndim+1-i]
+        length(val) != p && error(string(
+            "Size of output array ($(length(retvalsa))) does not equal number of elements to be read (",
+            p,
+            ")!",
+        ))
+        nc_put_vara_x(v, gstart, gcount, val)
     end
 end
 
 @generated function putvar(v::NcVar{T,N}, val::Any, I::Integer...) where {T,N}
 
     N == length(I) || error("Dimension mismatch")
-    if N==0
-      quote
-        gstart[1]=0
-        nc_put_var1_x(v,gstart,val[1])
-      end
+    if N == 0
+        quote
+            gstart[1] = 0
+            nc_put_var1_x(v, gstart, val[1])
+        end
     else
-      quote
-        @nexprs $N i->gstart[v.ndim+1-i]=I[i]-1
-        @nall($N,d->((I[d]<=v.dim[d].dimlen && I[d]>0) || v.dim[d].unlim)) || throw(BoundsError(v,I))
-        nc_put_var1_x(v,gstart,val[1])
-      end
+        quote
+            @nexprs $N i -> gstart[v.ndim+1-i] = I[i] - 1
+            @nall(
+                $N,
+                d -> ((I[d] <= v.dim[d].dimlen && I[d] > 0) || v.dim[d].unlim),
+            ) || throw(BoundsError(v, I))
+            nc_put_var1_x(v, gstart, val[1])
+        end
     end
 
 end
@@ -500,28 +682,57 @@ for (t, ending, arname) in funext
     fname = Symbol("nc_put_vara_$ending")
     fname1 = Symbol("nc_put_var1_$ending")
     arsym = Symbol(arname)
-    @eval nc_put_vara_x(v::NcVar,start::Vector{UInt}, count::Vector{UInt}, vals::AbstractArray{$t})=$fname(v.ncid,v.varid,start,count,vals)
-    @eval nc_put_var1_x(v::NcVar,start::Vector{UInt},val::$t)=begin $(arsym)[1]=val; $fname1(v.ncid,v.varid,start,$(arsym)) end
+    @eval nc_put_vara_x(
+        v::NcVar,
+        start::Vector{UInt},
+        count::Vector{UInt},
+        vals::AbstractArray{$t},
+    ) = $fname(v.ncid, v.varid, start, count, vals)
+    @eval nc_put_var1_x(v::NcVar, start::Vector{UInt}, val::$t) = begin
+        $(arsym)[1] = val
+        $fname1(v.ncid, v.varid, start, $(arsym))
+    end
 end
 
-nc_put_vara_x(v::NcVar{ASCIIChar,N,NC_CHAR},start::Vector{UInt}, count::Vector{UInt}, vals::AbstractArray{ASCIIChar}) where {N}=nc_put_vara_text(v.ncid,v.varid,start,count,vals)
-nc_put_var1_x(v::NcVar{ASCIIChar,N,NC_CHAR},start::Vector{UInt},val::ASCIIChar) where {N}=begin vals=UInt8[val]; nc_put_var1_text(v.ncid,v.varid,start,count,vals) end
-
-function nc_put_vara_x(v::NcVar{String,N,NC_STRING}, start, count,vals::AbstractArray{String}) where N
-    vals_p = map(x->pointer(x),vals)
-    nc_put_vara_string(v.ncid,v.varid,start,count,vals_p)
+nc_put_vara_x(
+    v::NcVar{ASCIIChar,N,NC_CHAR},
+    start::Vector{UInt},
+    count::Vector{UInt},
+    vals::AbstractArray{ASCIIChar},
+) where {N} = nc_put_vara_text(v.ncid, v.varid, start, count, vals)
+nc_put_var1_x(
+    v::NcVar{ASCIIChar,N,NC_CHAR},
+    start::Vector{UInt},
+    val::ASCIIChar,
+) where {N} = begin
+    vals = UInt8[val]
+    nc_put_var1_text(v.ncid, v.varid, start, count, vals)
 end
 
-function nc_put_var1_x(v::NcVar{String,N,NC_STRING},start::Vector{UInt},val::String) where N
-  val_p = [pointer(val)]
-  nc_put_var1_string(v.ncid,v.varid,start,val_p)
+function nc_put_vara_x(
+    v::NcVar{String,N,NC_STRING},
+    start,
+    count,
+    vals::AbstractArray{String},
+) where {N}
+    vals_p = map(x -> pointer(x), vals)
+    nc_put_vara_string(v.ncid, v.varid, start, count, vals_p)
+end
+
+function nc_put_var1_x(
+    v::NcVar{String,N,NC_STRING},
+    start::Vector{UInt},
+    val::String,
+) where {N}
+    val_p = [pointer(val)]
+    nc_put_var1_string(v.ncid, v.varid, start, val_p)
 end
 
 
-function Base.push!(v::NcVar,a::AbstractArray)
+function Base.push!(v::NcVar, a::AbstractArray)
     sold = size(v)
     N = ndims(v)
-    iunlim = findall(map(x->x.unlim,v.dim))
+    iunlim = findall(map(x -> x.unlim, v.dim))
     length(iunlim) == 1 || error("You can only push to a NetCDF variable with one unlimited dimension")
     st = fill(1, N)
     st[iunlim[1]] = sold[iunlim[1]] + 1
@@ -533,10 +744,10 @@ function Base.push!(v::NcVar,a::AbstractArray)
     else
         error("You can only push variables that have equal or one fewer dimension than the NetCDF Variable")
     end
-    NetCDF.putvar(v, a, start=st, count=co)
+    NetCDF.putvar(v, a, start = st, count = co)
 end
 
-function Base.push!(v::NcVar{T,1}, a::Number) where T
+function Base.push!(v::NcVar{T,1}, a::Number) where {T}
     push!(v, collect(a))
 end
 
@@ -549,14 +760,14 @@ function sync(nc::NcFile)
     nc_sync(nc.ncid)
 end
 
-function setcompression(v::NcVar,mode)
+function setcompression(v::NcVar, mode)
     if v.compress > -1
         if (NC_NETCDF4 & mode) == 0
             warn("Compression only possible for NetCDF4 file format. Compression will be ingored.")
             v.compress = -1
         else
-            v.compress = min(v.compress,9)
-            nc_def_var_deflate(v.ncid, v.varid, Int32(1), Int32(1), v.compress);
+            v.compress = min(v.compress, 9)
+            nc_def_var_deflate(v.ncid, v.varid, Int32(1), Int32(1), v.compress)
         end
     end
 end
@@ -572,45 +783,77 @@ Creates a new NetCDF file. Here, `name`
 * `gatts` a Dict containing global attributes of the NetCDF file
 * `mode` NetCDF file type (`NC_NETCDF4`, `NC_CLASSIC_MODEL` or `NC_64BIT_OFFSET`), defaults to `NC_NETCDF4`
 """
-function create(name::AbstractString,varlist::Array{<:NcVar};gatts::Dict=Dict{Any,Any}(),mode::UInt16=NC_NETCDF4)
+function create(
+    name::AbstractString,
+    varlist::Array{<:NcVar};
+    gatts::Dict = Dict{Any,Any}(),
+    mode::UInt16 = NC_NETCDF4,
+)
 
     #Create the file
-    id = nc_create(name,mode)
+    id = nc_create(name, mode)
     # Collect Dimensions and set NetCDF ID
     vars = Dict{String,NcVar}()
     varlist = collect(NcVar, varlist)
     dims = Set{NcDim}()
     for v in varlist
-        v.ncid=id
+        v.ncid = id
         for d in v.dim
-            push!(dims,d)
+            push!(dims, d)
         end
     end
     nunlim = 0
     ndim = Int32(length(dims))
 
     #Create the NcFile Object
-    nc = NcFile(id,Int32(length(vars)),ndim,zero(Int32),vars,Dict{String,NcDim}(),Dict{Any,Any}(),Int32[],name,NC_WRITE,true)
+    nc = NcFile(
+        id,
+        Int32(length(vars)),
+        ndim,
+        zero(Int32),
+        vars,
+        Dict{String,NcDim}(),
+        Dict{Any,Any}(),
+        Int32[],
+        name,
+        NC_WRITE,
+        true,
+    )
 
     for d in dims
         create_dim(nc, d)
         if d.unlim
-          push!(nc.unlimdimids, d.dimid)
+            push!(nc.unlimdimids, d.dimid)
         end
-        if (length(d.vals)>0) & (!haskey(nc.vars,d.name))
+        if (length(d.vals) > 0) & (!haskey(nc.vars, d.name))
             elt = eltype(d.vals)
-            push!(varlist,NcVar{elt,1,jl2nc(elt)}(id,varida[1],1,length(d.atts),jl2nc(elt),d.name,[d.dimid],[d],d.atts,-1,(zero(Int32),)))
+            push!(
+                varlist,
+                NcVar{elt,1,jl2nc(elt)}(
+                    id,
+                    varida[1],
+                    1,
+                    length(d.atts),
+                    jl2nc(elt),
+                    d.name,
+                    [d.dimid],
+                    [d],
+                    d.atts,
+                    -1,
+                    (zero(Int32),),
+                ),
+            )
         end
     end
 
     # Create variables in the file
     for v in varlist
-        create_var(nc,v,mode)
+        create_var(nc, v, mode)
     end
 
     # Put global attributes
     if !isempty(gatts)
-        putatt(nc,gatts)
+        putatt(nc, gatts)
     end
 
     # Leave define mode
@@ -619,15 +862,19 @@ function create(name::AbstractString,varlist::Array{<:NcVar};gatts::Dict=Dict{An
     for d in nc.dim
         #Write dimension variable
         if length(d[2].vals) > 0
-            putvar(nc,d[2].name,d[2].vals)
+            putvar(nc, d[2].name, d[2].vals)
         end
     end
 
-    return(nc)
+    return (nc)
 end
 
-create(name::AbstractString,varlist::NcVar...;gatts::Dict=Dict{Any,Any}(),mode::UInt16=NC_NETCDF4) =
-    create(name,NcVar[varlist[i] for i=1:length(varlist)];gatts=gatts,mode=mode)
+create(
+    name::AbstractString,
+    varlist::NcVar...;
+    gatts::Dict = Dict{Any,Any}(),
+    mode::UInt16 = NC_NETCDF4,
+) = create(name, NcVar[varlist[i] for i = 1:length(varlist)]; gatts = gatts, mode = mode)
 
 """
     NetCDF.close(nc::NcFile)
@@ -654,8 +901,13 @@ Note that it is in the user's responsibility to close the file after usage using
 * `mode` mode in which the file is opened, defaults to `NC_NOWRITE`, choose `NC_WRITE` for write access
 * `readdimvar` determines if dimension variables will be read into the file structure, default is `false`
 """
-function open(fil::AbstractString,v::AbstractString; mode::Integer=NC_NOWRITE, readdimvar::Bool=false)
-    nc=open(fil,mode=mode,readdimvar=readdimvar)
+function open(
+    fil::AbstractString,
+    v::AbstractString;
+    mode::Integer = NC_NOWRITE,
+    readdimvar::Bool = false,
+)
+    nc = open(fil, mode = mode, readdimvar = readdimvar)
     nc.vars[v]
 end
 
@@ -669,13 +921,13 @@ opens the NetCDF file `fil` and returns a `NcFile` handle. Note that it is in th
 * `mode` mode in which the file is opened, defaults to `NC_NOWRITE`, choose `NC_WRITE` for write access
 * `readdimvar` determines if dimension variables will be read into the file structure, default is `false`
 """
-function open(fil::AbstractString; mode::Integer=NC_NOWRITE, readdimvar::Bool=false)
+function open(fil::AbstractString; mode::Integer = NC_NOWRITE, readdimvar::Bool = false)
 
     # Open netcdf file
-    ncid = nc_open(fil,mode)
+    ncid = nc_open(fil, mode)
 
     #Get initial information
-    ndim,nvar,ngatt,nunlimdimid = nc_inq(ncid)
+    ndim, nvar, ngatt, nunlimdimid = nc_inq(ncid)
 
     #Get unlimited dimensions
     nunlimdims = Ref(Int32(0))
@@ -684,29 +936,62 @@ function open(fil::AbstractString; mode::Integer=NC_NOWRITE, readdimvar::Bool=fa
     nc_inq_unlimdims(ncid, nunlimdims, unlimdims)
 
     #Create ncdf object
-    ncf = NcFile(ncid,Int32(nvar-ndim),ndim,ngatt,Dict{String,NcVar}(),Dict{String,NcDim}(),Dict{Any,Any}(),unlimdims,abspath(fil),mode,false)
+    ncf = NcFile(
+        ncid,
+        Int32(nvar - ndim),
+        ndim,
+        ngatt,
+        Dict{String,NcVar}(),
+        Dict{String,NcDim}(),
+        Dict{Any,Any}(),
+        unlimdims,
+        abspath(fil),
+        mode,
+        false,
+    )
 
     #Read global attributes
-    ncf.gatts=getatts_all(ncid,NC_GLOBAL,ngatt)
+    ncf.gatts = getatts_all(ncid, NC_GLOBAL, ngatt)
 
     #Read dimensions
     for dimid = 0:ndim-1
-        (name,dimlen)=nc_inq_dim(ncid,dimid)
-        ncf.dim[name]=NcDim(ncid,dimid,-1,name,dimlen,[],Dict{Any,Any}(),in(dimid, unlimdims) ? true : false)
+        (name, dimlen) = nc_inq_dim(ncid, dimid)
+        ncf.dim[name] = NcDim(
+            ncid,
+            dimid,
+            -1,
+            name,
+            dimlen,
+            [],
+            Dict{Any,Any}(),
+            in(dimid, unlimdims) ? true : false,
+        )
     end
 
     #Read variable information
     for varid = 0:(nvar-1)
-        (name,nctype,dimids,natts,vndim,isdimvar,chunksize) = nc_inq_var(ncf,varid)
+        (name, nctype, dimids, natts, vndim, isdimvar, chunksize) = nc_inq_var(ncf, varid)
         if (isdimvar)
-            ncf.dim[name].varid=varid
+            ncf.dim[name].varid = varid
         end
-        atts = getatts_all(ncid,varid,natts)
-        vdim = Array{NcDim}(undef,length(dimids))
+        atts = getatts_all(ncid, varid, natts)
+        vdim = Array{NcDim}(undef, length(dimids))
         for (i, did) in enumerate(dimids)
-            vdim[i] = ncf.dim[getdimnamebyid(ncf,did)]
+            vdim[i] = ncf.dim[getdimnamebyid(ncf, did)]
         end
-        ncf.vars[name]=NcVar{nctype2jltype[nctype],Int(vndim),Int(nctype)}(ncid,Int32(varid),vndim,natts,nctype,name,dimids[vndim:-1:1],vdim[vndim:-1:1],atts,0,chunksize)
+        ncf.vars[name] = NcVar{nctype2jltype[nctype],Int(vndim),Int(nctype)}(
+            ncid,
+            Int32(varid),
+            vndim,
+            natts,
+            nctype,
+            name,
+            dimids[vndim:-1:1],
+            vdim[vndim:-1:1],
+            atts,
+            0,
+            chunksize,
+        )
     end
     readdimvar == true && _readdimvars(ncf)
     return ncf
@@ -722,13 +1007,13 @@ data = open("myfile.nc","myvar") do v
   NetCDF.readvar(v,start=[1,1,1], count=[-1,-1,1])
 end
 """
-function open(f::Function, args...;kwargs...)
-  io = open(args...;kwargs...)
-  try
-    f(io)
-  finally
-    close(io)
-  end
+function open(f::Function, args...; kwargs...)
+    io = open(args...; kwargs...)
+    try
+        f(io)
+    finally
+        close(io)
+    end
 end
 
 """
@@ -743,13 +1028,13 @@ NetCDF.create("newfile.nc",v) do nc
   nc["obs"][:] = rand(10)
 end
 """
-function create(f::Function, args...;kwargs...)
-  io = create(args...;kwargs...)
-  try
-    f(io)
-  finally
-    close(io)
-  end
+function create(f::Function, args...; kwargs...)
+    io = create(args...; kwargs...)
+    try
+        f(io)
+    finally
+        close(io)
+    end
 end
 
 # Define some high-level functions
@@ -770,14 +1055,24 @@ To read the second slice of a 3D NetCDF variable one can write:
     ncread("filename","varname", start=[1,1,2], count = [-1,-1,1])
 
 """
-function ncread(fil::AbstractString,vname::AbstractString;start::Array{T}=Array{Int}(undef,0),count::Array{T}=Array{Int}(undef,0)) where T<:Integer
+function ncread(
+    fil::AbstractString,
+    vname::AbstractString;
+    start::Array{T} = Array{Int}(undef, 0),
+    count::Array{T} = Array{Int}(undef, 0),
+) where {T<:Integer}
     open(fil) do nc
-      length(start)==0 && (start=defaultstart(nc[vname]))
-      length(count)==0 && (count=defaultcount(nc[vname]))
-      readvar(nc[vname],start=start,count=count)
+        length(start) == 0 && (start = defaultstart(nc[vname]))
+        length(count) == 0 && (count = defaultcount(nc[vname]))
+        readvar(nc[vname], start = start, count = count)
     end
 end
-ncread(fil::AbstractString,vname::AbstractString,start::Array{T,1},count::Array{T,1}) where {T<:Integer}=ncread(fil,vname,start=start,count=count)
+ncread(
+    fil::AbstractString,
+    vname::AbstractString,
+    start::Array{T,1},
+    count::Array{T,1},
+) where {T<:Integer} = ncread(fil, vname, start = start, count = count)
 
 """
     ncread!(filename, varname, d)
@@ -797,9 +1092,15 @@ To read the second slice of a 3D NetCDF variable one can write:
     ncread!("filename","varname", d, start=[1,1,2], count = [-1,-1,1])
 
 """
-function ncread!(fil::AbstractString,vname::AbstractString,vals::AbstractArray;start::Vector{Int}=ones(Int,ndims(vals)),count::Vector{Int}=[size(vals,i) for i=1:ndims(vals)])
+function ncread!(
+    fil::AbstractString,
+    vname::AbstractString,
+    vals::AbstractArray;
+    start::Vector{Int} = ones(Int, ndims(vals)),
+    count::Vector{Int} = [size(vals, i) for i = 1:ndims(vals)],
+)
     open(fil) do nc
-      readvar!(nc,vname,vals,start=start,count=count)
+        readvar!(nc, vname, vals, start = start, count = count)
     end
 end
 
@@ -809,7 +1110,7 @@ end
 prints information on the variables, dimension and attributes conatained in the file
 """
 function ncinfo(fil::AbstractString)
-  open(show,fil)
+    open(show, fil)
 end
 
 iswritable(nc::NcFile) = (nc.omode & NC_WRITE) != zero(UInt16)
@@ -825,26 +1126,34 @@ Writes the array `x` to the file `fil` and variable `vname`.
 * `start` Vector of length `ndim(v)` setting the starting index for writing for each dimension
 * `count` Vector of length `ndim(v)` setting the count of values to be written along each dimension. The value -1 is treated as a special case to write all values from this dimension. This is usually inferred by the given array size.
 """
-function ncwrite(x::Array,fil::AbstractString,vname::AbstractString;start=ones(Int,length(size(x))),count=[size(x)...])
-    open(fil,mode=NC_WRITE) do nc
-      if (nc.omode==NC_NOWRITE)
-        close(nc)
-        println("reopening file in WRITE mode")
-        open(fil,mode=NC_WRITE)
-      end
-      putvar(nc,vname,x,start=start,count=count)
+function ncwrite(
+    x::Array,
+    fil::AbstractString,
+    vname::AbstractString;
+    start = ones(Int, length(size(x))),
+    count = [size(x)...],
+)
+    open(fil, mode = NC_WRITE) do nc
+        if (nc.omode == NC_NOWRITE)
+            close(nc)
+            println("reopening file in WRITE mode")
+            open(fil, mode = NC_WRITE)
+        end
+        putvar(nc, vname, x, start = start, count = count)
     end
 end
-ncwrite(x::Array,fil::AbstractString,vname::AbstractString,start::Array)=ncwrite(x,fil,vname,start=start)
+ncwrite(x::Array, fil::AbstractString, vname::AbstractString, start::Array) =
+    ncwrite(x, fil, vname, start = start)
 
 """
     ncgetatt(filename, varname, attname)
 
 This reads a NetCDF attribute `attname` from the specified file and variable. To read global attributes, set varname to `Global`.
 """
-function ncgetatt(fil::AbstractString,vname::AbstractString,att::AbstractString)
+function ncgetatt(fil::AbstractString, vname::AbstractString, att::AbstractString)
     open(fil) do nc
-      haskey(nc.vars,vname) ? get(nc.vars[vname].atts,att,nothing) : get(nc.gatts,att,nothing)
+        haskey(nc.vars, vname) ? get(nc.vars[vname].atts, att, nothing) :
+        get(nc.gatts, att, nothing)
     end
 end
 
@@ -853,32 +1162,32 @@ end
 # if the file does not exist, it will be created
 # if the file already exists, the variable will be added to the file
 
-function create_dim(nc,dim)
+function create_dim(nc, dim)
     nc_redef(nc)
-    nc_def_dim(nc.ncid,dim.name,dim.dimlen,dima);
-    dim.dimid=dima[1];
-    nc.dim[dim.name]=dim;
+    nc_def_dim(nc.ncid, dim.name, dim.dimlen, dima)
+    dim.dimid = dima[1]
+    nc.dim[dim.name] = dim
 end
 
 
-function create_var(nc,v,mode)
+function create_var(nc, v, mode)
     nc_redef(nc)
 
-    v.dimids=Int32[v.dim[i].dimid for i=1:length(v.dim)]
-    for i=1:v.ndim
+    v.dimids = Int32[v.dim[i].dimid for i = 1:length(v.dim)]
+    for i = 1:v.ndim
         dumids[i] = v.dimids[v.ndim+1-i]
     end
-    nc_def_var(nc.ncid,v.name,v.nctype,v.ndim,dumids,vara)
-    v.varid=vara[1];
-    if any(i->i>0,v.chunksize)
-        for i=1:v.ndim
+    nc_def_var(nc.ncid, v.name, v.nctype, v.ndim, dumids, vara)
+    v.varid = vara[1]
+    if any(i -> i > 0, v.chunksize)
+        for i = 1:v.ndim
             chunk_sizea[i] = v.chunksize[i]
         end
         nc_def_var_chunking(nc.ncid, v.varid, NC_CHUNKED, chunk_sizea)
     end
     nc.vars[v.name] = v
-    putatt(nc.ncid,v.varid,v.atts)
-    setcompression(v,mode)
+    putatt(nc.ncid, v.varid, v.atts)
+    setcompression(v, mode)
 end
 
 """
@@ -897,126 +1206,163 @@ Then the next dimension is entered and so on. Have a look at examples/high.jl fo
 - **t** variable type, currently supported types are: const `NC_BYTE`, `NC_CHAR`, `NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_LONG`, `NC_DOUBLE`
 - **mode** file creation mode, only valid when new file is created, choose one of: `NC_NETCDF4`, `NC_CLASSIC_MODEL`, `NC_64BIT_OFFSET`
 """
-function nccreate(fil::AbstractString,varname::AbstractString,dims...;atts::Dict=Dict{Any,Any}(),gatts::Dict=Dict{Any,Any}(),compress::Integer=-1,t::Union{DataType,Integer}=NC_DOUBLE,mode::UInt16=NC_NETCDF4,chunksize=(0,))
+function nccreate(
+    fil::AbstractString,
+    varname::AbstractString,
+    dims...;
+    atts::Dict = Dict{Any,Any}(),
+    gatts::Dict = Dict{Any,Any}(),
+    compress::Integer = -1,
+    t::Union{DataType,Integer} = NC_DOUBLE,
+    mode::UInt16 = NC_NETCDF4,
+    chunksize = (0,),
+)
   # Checking dims argument for correctness
-  dim = parsedimargs(dims)
+    dim = parsedimargs(dims)
   # Check chunksize
-  chunksize = chunksize[1]==0 ? ntuple(i->0,length(dim)) : chunksize
+    chunksize = chunksize[1] == 0 ? ntuple(i -> 0, length(dim)) : chunksize
   # create the NcVar object
-  v = NcVar(varname,dim,atts=atts,compress=compress,t=t,chunksize=chunksize)
+    v = NcVar(varname, dim, atts = atts, compress = compress, t = t, chunksize = chunksize)
   # Test if the file already exists
-  if isfile(fil)
-    nc = open(fil,mode=NC_WRITE) do nc
-      v.ncid = nc.ncid
-      haskey(nc.vars,varname) && error("Variable $varname already exists in file $fil")
+    if isfile(fil)
+        nc = open(fil, mode = NC_WRITE) do nc
+            v.ncid = nc.ncid
+            haskey(
+                nc.vars,
+                varname,
+            ) && error("Variable $varname already exists in file $fil")
       # Check if dimensions exist, if not, create
       # Remember if dimension was created
 
-      dcreate = falses(length(dim))
-      for i=1:length(dim)
-        if !haskey(nc.dim,dim[i].name)
-          create_dim(nc,dim[i])
-          v.dimids[i] = dim[i].dimid
-          if length(dim[i].vals)>0
-            elt = eltype(dim[i].vals)
-            create_var(nc,NcVar{elt,1,jl2nc(elt)}(nc.ncid,0,1,length(dim[i].atts),jl2nc(elt),dim[i].name,[dim[i].dimid],[dim[i]],dim[i].atts,-1,(0,)),mode)
-          end
-          dcreate[i] = true
-        else
-          v.dimids[i] = nc.dim[dim[i].name].dimid
-          v.dim[i] = nc.dim[dim[i].name]
-          dcreate[i] = false
-        end
-      end
+            dcreate = falses(length(dim))
+            for i = 1:length(dim)
+                if !haskey(nc.dim, dim[i].name)
+                    create_dim(nc, dim[i])
+                    v.dimids[i] = dim[i].dimid
+                    if length(dim[i].vals) > 0
+                        elt = eltype(dim[i].vals)
+                        create_var(
+                            nc,
+                            NcVar{elt,1,jl2nc(elt)}(
+                                nc.ncid,
+                                0,
+                                1,
+                                length(dim[i].atts),
+                                jl2nc(elt),
+                                dim[i].name,
+                                [dim[i].dimid],
+                                [dim[i]],
+                                dim[i].atts,
+                                -1,
+                                (0,),
+                            ),
+                            mode,
+                        )
+                    end
+                    dcreate[i] = true
+                else
+                    v.dimids[i] = nc.dim[dim[i].name].dimid
+                    v.dim[i] = nc.dim[dim[i].name]
+                    dcreate[i] = false
+                end
+            end
 
       # Create variable
-      create_var(nc, v, mode)
-      nc_enddef(nc)
-      for i = 1:length(dim)
-        if dcreate[i] & !isempty(dim[i].vals)
-          ncwrite(dim[i].vals,fil,dim[i].name)
+            create_var(nc, v, mode)
+            nc_enddef(nc)
+            for i = 1:length(dim)
+                if dcreate[i] & !isempty(dim[i].vals)
+                    ncwrite(dim[i].vals, fil, dim[i].name)
+                end
+            end
         end
-      end
+    else
+        nc = create(fil, v, gatts = gatts, mode = mode | NC_NOCLOBBER)
+        for d in dim
+            !isempty(d.vals) && ncwrite(d.vals, fil, d.name)
+        end
+        close(nc)
     end
-  else
-    nc = create(fil,v,gatts=gatts,mode=mode | NC_NOCLOBBER)
-    for d in dim
-      !isempty(d.vals) && ncwrite(d.vals,fil,d.name)
-    end
-    close(nc)
-  end
-  return nothing
+    return nothing
 end
 
 #show{T<:Any,N}(io::IO,a::NcVar{T,N})=println(io,a.name)
 #showcompact{T<:Any,N}(io::IO,a::NcVar{T,N})=println(io,a.name)
-function show(io::IO,nc::NcFile)
-    nrow,ncol=Base.displaysize(io)
-    hline = repeat("-",ncol)
-    l1=div(ncol,3)
-    l2=2*l1
-    println(io,"")
-    println(io,"##### NetCDF File #####")
-    println(io,"")
-    println(io,nc.name)
-    println(io,"")
-    println(io,"##### Dimensions #####")
-    println(io,"")
-    println(io,tolen("Name",l2),tolen("Length",l1))
-    println(io,hline)
-    for d in nc.dim
-        println(io,tolen(d[2].name,l2),tolen(d[2].unlim ? string("UNLIMITED (" ,d[2].dimlen," currently)") : d[2].dimlen,l1))
-    end
-    l1 = div(ncol,5)
+function show(io::IO, nc::NcFile)
+    nrow, ncol = Base.displaysize(io)
+    hline = repeat("-", ncol)
+    l1 = div(ncol, 3)
     l2 = 2 * l1
-    println(io,"")
-    println(io,"##### Variables #####")
-    println(io,"")
-    println(io,tolen("Name",l2),tolen("Type",l1),tolen("Dimensions",l2))
-    println(io,hline)
+    println(io, "")
+    println(io, "##### NetCDF File #####")
+    println(io, "")
+    println(io, nc.name)
+    println(io, "")
+    println(io, "##### Dimensions #####")
+    println(io, "")
+    println(io, tolen("Name", l2), tolen("Length", l1))
+    println(io, hline)
+    for d in nc.dim
+        println(
+            io,
+            tolen(d[2].name, l2),
+            tolen(
+                d[2].unlim ? string("UNLIMITED (", d[2].dimlen, " currently)") :
+                d[2].dimlen,
+                l1,
+            ),
+        )
+    end
+    l1 = div(ncol, 5)
+    l2 = 2 * l1
+    println(io, "")
+    println(io, "##### Variables #####")
+    println(io, "")
+    println(io, tolen("Name", l2), tolen("Type", l1), tolen("Dimensions", l2))
+    println(io, hline)
     for v in nc.vars
-        s1 = string(tolen(v[2].name,l2))
-        s2 = string(tolen(nctype2string[Int(v[2].nctype)],l1))
+        s1 = string(tolen(v[2].name, l2))
+        s2 = string(tolen(nctype2string[Int(v[2].nctype)], l1))
         s3 = ""
         for d in v[2].dim
-            s3 = string(s3,d.name," ")
+            s3 = string(s3, d.name, " ")
         end
-        println(io,s1,s2,tolen(s3,l2))
+        println(io, s1, s2, tolen(s3, l2))
     end
-    l1 = div(ncol,4)
+    l1 = div(ncol, 4)
     l2 = 2 * l1
-    println(io,"")
-    println(io,"##### Attributes #####")
-    println(io,"")
-    println(io,tolen("Variable",l1),tolen("Name",l1),tolen("Value",l2))
-    println(io,hline)
+    println(io, "")
+    println(io, "##### Attributes #####")
+    println(io, "")
+    println(io, tolen("Variable", l1), tolen("Name", l1), tolen("Value", l2))
+    println(io, hline)
     for a in nc.gatts
-        println(io,tolen("global",l1),tolen(a[1],l1),tolen(a[2],l2))
+        println(io, tolen("global", l1), tolen(a[1], l1), tolen(a[2], l2))
     end
     for v in nc.vars
         for a in v[2].atts
-            println(io,tolen(v[2].name,l1),tolen(a[1],l1),tolen(a[2],l2))
+            println(io, tolen(v[2].name, l1), tolen(a[1], l1), tolen(a[2], l2))
         end
     end
 end
 
-tolen(s::Any, l::Number) = tolen(string(s), round(Int,l))
+tolen(s::Any, l::Number) = tolen(string(s), round(Int, l))
 function tolen(s::AbstractString, l::Integer)
     ls = length(s)
-    if ls<l
-        return rpad(s,l)
-    elseif ls>l
-        return string(s[1:prevind(s,l-1)],"..")
+    if ls < l
+        return rpad(s, l)
+    elseif ls > l
+        return string(s[1:prevind(s, l - 1)], "..")
     else
         return s
     end
 end
 function tolen(s::Array{String,1}, l::Number)
     cs = "["
-    for se = s
-      cs*=string(se,", ")
+    for se in s
+        cs *= string(se, ", ")
     end
-    cs = isempty(s) ? string(cs,']') : string(cs[1:end-2],']')
+    cs = isempty(s) ? string(cs, ']') : string(cs[1:end-2], ']')
     return tolen(cs, l)
 end
 

--- a/src/netcdf_c.jl
+++ b/src/netcdf_c.jl
@@ -183,1332 +183,4212 @@ const NC_EXDR = -32
 const NC_SYSERR = -31
 const NC_FATAL = 1
 
-const nc_type=Cint
+const nc_type = Cint
 
 mutable struct nc_vlen_t
     len::Integer
     p::Ptr{Cvoid}
 end
 
-const nclong=Cint
+const nclong = Cint
 
 
 function nc_inq_libvers()
-    ccall((:nc_inq_libvers,libnetcdf),Ptr{UInt8},())
+    ccall((:nc_inq_libvers, libnetcdf), Ptr{UInt8}, ())
 end
 
 function nc_strerror(ncerr::Integer)
-    ccall((:nc_strerror,libnetcdf),Ptr{UInt8},(Cint,),ncerr)
+    ccall((:nc_strerror, libnetcdf), Ptr{UInt8}, (Cint,), ncerr)
 end
 
-function nc__create(path,cmode::Integer,initialsz::Integer,chunksizehintp,ncidp)
-    check(ccall((:nc__create,libnetcdf),Cint,(Ptr{UInt8},Cint,Cint,Ptr{Cint},Ptr{Cint}),path,cmode,initialsz,chunksizehintp,ncidp))
+function nc__create(path, cmode::Integer, initialsz::Integer, chunksizehintp, ncidp)
+    check(ccall(
+        (:nc__create, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        path,
+        cmode,
+        initialsz,
+        chunksizehintp,
+        ncidp,
+    ))
 end
 
-function nc_create(path,cmode::Integer,ncidp)
-    check(ccall((:nc_create,libnetcdf),Cint,(Ptr{UInt8},Cint,Ptr{Cint}),path,cmode,ncidp))
+function nc_create(path, cmode::Integer, ncidp)
+    check(ccall(
+        (:nc_create, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Ptr{Cint}),
+        path,
+        cmode,
+        ncidp,
+    ))
 end
 
-function nc__open(path,mode::Integer,chunksizehintp,ncidp)
-    check(ccall((:nc__open,libnetcdf),Cint,(Ptr{UInt8},Cint,Ptr{Cint},Ptr{Cint}),path,mode,chunksizehintp,ncidp))
+function nc__open(path, mode::Integer, chunksizehintp, ncidp)
+    check(ccall(
+        (:nc__open, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Ptr{Cint}, Ptr{Cint}),
+        path,
+        mode,
+        chunksizehintp,
+        ncidp,
+    ))
 end
 
-function nc_open(path,mode::Integer,ncidp)
-    check(ccall((:nc_open,libnetcdf),Cint,(Ptr{UInt8},Cint,Ptr{Cint}),path,mode,ncidp))
+function nc_open(path, mode::Integer, ncidp)
+    check(ccall(
+        (:nc_open, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Ptr{Cint}),
+        path,
+        mode,
+        ncidp,
+    ))
 end
 
-function nc_inq_path(ncid::Integer,pathlen,path)
-    check(ccall((:nc_inq_path,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{UInt8}),ncid,pathlen,path))
+function nc_inq_path(ncid::Integer, pathlen, path)
+    check(ccall(
+        (:nc_inq_path, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        pathlen,
+        path,
+    ))
 end
 
-function nc_inq_ncid(ncid::Integer,name,grp_ncid)
-    check(ccall((:nc_inq_ncid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),ncid,name,grp_ncid))
+function nc_inq_ncid(ncid::Integer, name, grp_ncid)
+    check(ccall(
+        (:nc_inq_ncid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        name,
+        grp_ncid,
+    ))
 end
 
-function nc_inq_grps(ncid::Integer,numgrps,ncids)
-    check(ccall((:nc_inq_grps,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint}),ncid,numgrps,ncids))
+function nc_inq_grps(ncid::Integer, numgrps, ncids)
+    check(ccall(
+        (:nc_inq_grps, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        numgrps,
+        ncids,
+    ))
 end
 
-function nc_inq_grpname(ncid::Integer,name)
-    check(ccall((:nc_inq_grpname,libnetcdf),Cint,(Cint,Ptr{UInt8}),ncid,name))
+function nc_inq_grpname(ncid::Integer, name)
+    check(ccall((:nc_inq_grpname, libnetcdf), Cint, (Cint, Ptr{UInt8}), ncid, name))
 end
 
-function nc_inq_grpname_full(ncid::Integer,lenp,full_name)
-    check(ccall((:nc_inq_grpname_full,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{UInt8}),ncid,lenp,full_name))
+function nc_inq_grpname_full(ncid::Integer, lenp, full_name)
+    check(ccall(
+        (:nc_inq_grpname_full, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        lenp,
+        full_name,
+    ))
 end
 
-function nc_inq_grpname_len(ncid::Integer,lenp)
-    check(ccall((:nc_inq_grpname_len,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,lenp))
+function nc_inq_grpname_len(ncid::Integer, lenp)
+    check(ccall((:nc_inq_grpname_len, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, lenp))
 end
 
-function nc_inq_grp_parent(ncid::Integer,parent_ncid)
-    check(ccall((:nc_inq_grp_parent,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,parent_ncid))
+function nc_inq_grp_parent(ncid::Integer, parent_ncid)
+    check(ccall(
+        (:nc_inq_grp_parent, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}),
+        ncid,
+        parent_ncid,
+    ))
 end
 
-function nc_inq_grp_ncid(ncid::Integer,grp_name,grp_ncid)
-    check(ccall((:nc_inq_grp_ncid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),ncid,grp_name,grp_ncid))
+function nc_inq_grp_ncid(ncid::Integer, grp_name, grp_ncid)
+    check(ccall(
+        (:nc_inq_grp_ncid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        grp_name,
+        grp_ncid,
+    ))
 end
 
-function nc_inq_grp_full_ncid(ncid::Integer,full_name,grp_ncid)
-    check(ccall((:nc_inq_grp_full_ncid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),ncid,full_name,grp_ncid))
+function nc_inq_grp_full_ncid(ncid::Integer, full_name, grp_ncid)
+    check(ccall(
+        (:nc_inq_grp_full_ncid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        full_name,
+        grp_ncid,
+    ))
 end
 
-function nc_inq_varids(ncid::Integer,nvars,varids)
-    check(ccall((:nc_inq_varids,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint}),ncid,nvars,varids))
+function nc_inq_varids(ncid::Integer, nvars, varids)
+    check(ccall(
+        (:nc_inq_varids, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        nvars,
+        varids,
+    ))
 end
 
-function nc_inq_dimids(ncid::Integer,ndims,dimids,include_parents::Integer)
-    check(ccall((:nc_inq_dimids,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint},Cint),ncid,ndims,dimids,include_parents))
+function nc_inq_dimids(ncid::Integer, ndims, dimids, include_parents::Integer)
+    check(ccall(
+        (:nc_inq_dimids, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}, Cint),
+        ncid,
+        ndims,
+        dimids,
+        include_parents,
+    ))
 end
 
-function nc_inq_typeids(ncid::Integer,ntypes,typeids)
-    check(ccall((:nc_inq_typeids,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint}),ncid,ntypes,typeids))
+function nc_inq_typeids(ncid::Integer, ntypes, typeids)
+    check(ccall(
+        (:nc_inq_typeids, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        ntypes,
+        typeids,
+    ))
 end
 
-function nc_inq_type_equal(ncid1::Integer,typeid1::Integer,ncid2::Integer,typeid2::Integer,equal)
-    check(ccall((:nc_inq_type_equal,libnetcdf),Cint,(Cint,nc_type,Cint,nc_type,Ptr{Cint}),ncid1,typeid1,ncid2,typeid2,equal))
+function nc_inq_type_equal(
+    ncid1::Integer,
+    typeid1::Integer,
+    ncid2::Integer,
+    typeid2::Integer,
+    equal,
+)
+    check(ccall(
+        (:nc_inq_type_equal, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, nc_type, Ptr{Cint}),
+        ncid1,
+        typeid1,
+        ncid2,
+        typeid2,
+        equal,
+    ))
 end
 
-function nc_def_grp(parent_ncid::Integer,name,new_ncid)
-    check(ccall((:nc_def_grp,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),parent_ncid,name,new_ncid))
+function nc_def_grp(parent_ncid::Integer, name, new_ncid)
+    check(ccall(
+        (:nc_def_grp, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        parent_ncid,
+        name,
+        new_ncid,
+    ))
 end
 
-function nc_rename_grp(grpid::Integer,name)
-    check(ccall((:nc_rename_grp,libnetcdf),Cint,(Cint,Ptr{UInt8}),grpid,name))
+function nc_rename_grp(grpid::Integer, name)
+    check(ccall((:nc_rename_grp, libnetcdf), Cint, (Cint, Ptr{UInt8}), grpid, name))
 end
 
-function nc_def_compound(ncid::Integer,size::Integer,name,typeidp)
-    check(ccall((:nc_def_compound,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type}),ncid,size,name,typeidp))
+function nc_def_compound(ncid::Integer, size::Integer, name, typeidp)
+    check(ccall(
+        (:nc_def_compound, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}),
+        ncid,
+        size,
+        name,
+        typeidp,
+    ))
 end
 
-function nc_insert_compound(ncid::Integer,xtype::Integer,name,offset::Integer,field_typeid::Integer)
-    check(ccall((:nc_insert_compound,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Cint,nc_type),ncid,xtype,name,offset,field_typeid))
+function nc_insert_compound(
+    ncid::Integer,
+    xtype::Integer,
+    name,
+    offset::Integer,
+    field_typeid::Integer,
+)
+    check(ccall(
+        (:nc_insert_compound, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Cint, nc_type),
+        ncid,
+        xtype,
+        name,
+        offset,
+        field_typeid,
+    ))
 end
 
-function nc_insert_array_compound(ncid::Integer,xtype::Integer,name,offset::Integer,field_typeid::Integer,ndims::Integer,dim_sizes)
-    check(ccall((:nc_insert_array_compound,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Cint,nc_type,Cint,Ptr{Cint}),ncid,xtype,name,offset,field_typeid,ndims,dim_sizes))
+function nc_insert_array_compound(
+    ncid::Integer,
+    xtype::Integer,
+    name,
+    offset::Integer,
+    field_typeid::Integer,
+    ndims::Integer,
+    dim_sizes,
+)
+    check(ccall(
+        (:nc_insert_array_compound, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Cint, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        offset,
+        field_typeid,
+        ndims,
+        dim_sizes,
+    ))
 end
 
-function nc_inq_type(ncid::Integer,xtype::Integer,name,size)
-    check(ccall((:nc_inq_type,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint}),ncid,xtype,name,size))
+function nc_inq_type(ncid::Integer, xtype::Integer, name, size)
+    check(ccall(
+        (:nc_inq_type, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        size,
+    ))
 end
 
-function nc_inq_typeid(ncid::Integer,name,typeidp)
-    check(ccall((:nc_inq_typeid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{nc_type}),ncid,name,typeidp))
+function nc_inq_typeid(ncid::Integer, name, typeidp)
+    check(ccall(
+        (:nc_inq_typeid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{nc_type}),
+        ncid,
+        name,
+        typeidp,
+    ))
 end
 
-function nc_inq_compound(ncid::Integer,xtype::Integer,name,sizep,nfieldsp)
-    check(ccall((:nc_inq_compound,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint},Ptr{Cint}),ncid,xtype,name,sizep,nfieldsp))
+function nc_inq_compound(ncid::Integer, xtype::Integer, name, sizep, nfieldsp)
+    check(ccall(
+        (:nc_inq_compound, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        sizep,
+        nfieldsp,
+    ))
 end
 
-function nc_inq_compound_name(ncid::Integer,xtype::Integer,name)
-    check(ccall((:nc_inq_compound_name,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8}),ncid,xtype,name))
+function nc_inq_compound_name(ncid::Integer, xtype::Integer, name)
+    check(ccall(
+        (:nc_inq_compound_name, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}),
+        ncid,
+        xtype,
+        name,
+    ))
 end
 
-function nc_inq_compound_size(ncid::Integer,xtype::Integer,sizep)
-    check(ccall((:nc_inq_compound_size,libnetcdf),Cint,(Cint,nc_type,Ptr{Cint}),ncid,xtype,sizep))
+function nc_inq_compound_size(ncid::Integer, xtype::Integer, sizep)
+    check(ccall(
+        (:nc_inq_compound_size, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{Cint}),
+        ncid,
+        xtype,
+        sizep,
+    ))
 end
 
-function nc_inq_compound_nfields(ncid::Integer,xtype::Integer,nfieldsp)
-    check(ccall((:nc_inq_compound_nfields,libnetcdf),Cint,(Cint,nc_type,Ptr{Cint}),ncid,xtype,nfieldsp))
+function nc_inq_compound_nfields(ncid::Integer, xtype::Integer, nfieldsp)
+    check(ccall(
+        (:nc_inq_compound_nfields, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{Cint}),
+        ncid,
+        xtype,
+        nfieldsp,
+    ))
 end
 
-function nc_inq_compound_field(ncid::Integer,xtype::Integer,fieldid::Integer,name,offsetp,field_typeidp,ndimsp,dim_sizesp)
-    check(ccall((:nc_inq_compound_field,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{UInt8},Ptr{Cint},Ptr{nc_type},Ptr{Cint},Ptr{Cint}),ncid,xtype,fieldid,name,offsetp,field_typeidp,ndimsp,dim_sizesp))
+function nc_inq_compound_field(
+    ncid::Integer,
+    xtype::Integer,
+    fieldid::Integer,
+    name,
+    offsetp,
+    field_typeidp,
+    ndimsp,
+    dim_sizesp,
+)
+    check(ccall(
+        (:nc_inq_compound_field, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{UInt8}, Ptr{Cint}, Ptr{nc_type}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        xtype,
+        fieldid,
+        name,
+        offsetp,
+        field_typeidp,
+        ndimsp,
+        dim_sizesp,
+    ))
 end
 
-function nc_inq_compound_fieldname(ncid::Integer,xtype::Integer,fieldid::Integer,name)
-    check(ccall((:nc_inq_compound_fieldname,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{UInt8}),ncid,xtype,fieldid,name))
+function nc_inq_compound_fieldname(ncid::Integer, xtype::Integer, fieldid::Integer, name)
+    check(ccall(
+        (:nc_inq_compound_fieldname, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{UInt8}),
+        ncid,
+        xtype,
+        fieldid,
+        name,
+    ))
 end
 
-function nc_inq_compound_fieldindex(ncid::Integer,xtype::Integer,name,fieldidp)
-    check(ccall((:nc_inq_compound_fieldindex,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint}),ncid,xtype,name,fieldidp))
+function nc_inq_compound_fieldindex(ncid::Integer, xtype::Integer, name, fieldidp)
+    check(ccall(
+        (:nc_inq_compound_fieldindex, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        fieldidp,
+    ))
 end
 
-function nc_inq_compound_fieldoffset(ncid::Integer,xtype::Integer,fieldid::Integer,offsetp)
-    check(ccall((:nc_inq_compound_fieldoffset,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{Cint}),ncid,xtype,fieldid,offsetp))
+function nc_inq_compound_fieldoffset(
+    ncid::Integer,
+    xtype::Integer,
+    fieldid::Integer,
+    offsetp,
+)
+    check(ccall(
+        (:nc_inq_compound_fieldoffset, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        xtype,
+        fieldid,
+        offsetp,
+    ))
 end
 
-function nc_inq_compound_fieldtype(ncid::Integer,xtype::Integer,fieldid::Integer,field_typeidp)
-    check(ccall((:nc_inq_compound_fieldtype,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{nc_type}),ncid,xtype,fieldid,field_typeidp))
+function nc_inq_compound_fieldtype(
+    ncid::Integer,
+    xtype::Integer,
+    fieldid::Integer,
+    field_typeidp,
+)
+    check(ccall(
+        (:nc_inq_compound_fieldtype, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{nc_type}),
+        ncid,
+        xtype,
+        fieldid,
+        field_typeidp,
+    ))
 end
 
-function nc_inq_compound_fieldndims(ncid::Integer,xtype::Integer,fieldid::Integer,ndimsp)
-    check(ccall((:nc_inq_compound_fieldndims,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{Cint}),ncid,xtype,fieldid,ndimsp))
+function nc_inq_compound_fieldndims(ncid::Integer, xtype::Integer, fieldid::Integer, ndimsp)
+    check(ccall(
+        (:nc_inq_compound_fieldndims, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        xtype,
+        fieldid,
+        ndimsp,
+    ))
 end
 
-function nc_inq_compound_fielddim_sizes(ncid::Integer,xtype::Integer,fieldid::Integer,dim_sizes)
-    check(ccall((:nc_inq_compound_fielddim_sizes,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{Cint}),ncid,xtype,fieldid,dim_sizes))
+function nc_inq_compound_fielddim_sizes(
+    ncid::Integer,
+    xtype::Integer,
+    fieldid::Integer,
+    dim_sizes,
+)
+    check(ccall(
+        (:nc_inq_compound_fielddim_sizes, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        xtype,
+        fieldid,
+        dim_sizes,
+    ))
 end
 
-function nc_def_vlen(ncid::Integer,name,base_typeid::Integer,xtypep)
-    check(ccall((:nc_def_vlen,libnetcdf),Cint,(Cint,Ptr{UInt8},nc_type,Ptr{nc_type}),ncid,name,base_typeid,xtypep))
+function nc_def_vlen(ncid::Integer, name, base_typeid::Integer, xtypep)
+    check(ccall(
+        (:nc_def_vlen, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, nc_type, Ptr{nc_type}),
+        ncid,
+        name,
+        base_typeid,
+        xtypep,
+    ))
 end
 
-function nc_inq_vlen(ncid::Integer,xtype::Integer,name,datum_sizep,base_nc_typep)
-    check(ccall((:nc_inq_vlen,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint},Ptr{nc_type}),ncid,xtype,name,datum_sizep,base_nc_typep))
+function nc_inq_vlen(ncid::Integer, xtype::Integer, name, datum_sizep, base_nc_typep)
+    check(ccall(
+        (:nc_inq_vlen, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}, Ptr{nc_type}),
+        ncid,
+        xtype,
+        name,
+        datum_sizep,
+        base_nc_typep,
+    ))
 end
 
 function nc_free_vlen(vl)
-    check(ccall((:nc_free_vlen,libnetcdf),Cint,(Ptr{nc_vlen_t},),vl))
+    check(ccall((:nc_free_vlen, libnetcdf), Cint, (Ptr{nc_vlen_t},), vl))
 end
 
-function nc_free_vlens(len::Integer,vlens)
-    check(ccall((:nc_free_vlens,libnetcdf),Cint,(Cint,Ptr{nc_vlen_t}),len,vlens))
+function nc_free_vlens(len::Integer, vlens)
+    check(ccall((:nc_free_vlens, libnetcdf), Cint, (Cint, Ptr{nc_vlen_t}), len, vlens))
 end
 
-function nc_put_vlen_element(ncid::Integer,typeid1::Integer,vlen_element,len::Integer,data)
-    check(ccall((:nc_put_vlen_element,libnetcdf),Cint,(Cint,Cint,Ptr{Cvoid},Cint,Ptr{Cvoid}),ncid,typeid1,vlen_element,len,data))
+function nc_put_vlen_element(
+    ncid::Integer,
+    typeid1::Integer,
+    vlen_element,
+    len::Integer,
+    data,
+)
+    check(ccall(
+        (:nc_put_vlen_element, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cvoid}, Cint, Ptr{Cvoid}),
+        ncid,
+        typeid1,
+        vlen_element,
+        len,
+        data,
+    ))
 end
 
-function nc_get_vlen_element(ncid::Integer,typeid1::Integer,vlen_element,len,data)
-    check(ccall((:nc_get_vlen_element,libnetcdf),Cint,(Cint,Cint,Ptr{Cvoid},Ptr{Cint},Ptr{Cvoid}),ncid,typeid1,vlen_element,len,data))
+function nc_get_vlen_element(ncid::Integer, typeid1::Integer, vlen_element, len, data)
+    check(ccall(
+        (:nc_get_vlen_element, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        typeid1,
+        vlen_element,
+        len,
+        data,
+    ))
 end
 
-function nc_free_string(len::Integer,data)
-    check(ccall((:nc_free_string,libnetcdf),Cint,(Cint,Ptr{Ptr{UInt8}}),len,data))
+function nc_free_string(len::Integer, data)
+    check(ccall((:nc_free_string, libnetcdf), Cint, (Cint, Ptr{Ptr{UInt8}}), len, data))
 end
 
-function nc_inq_user_type(ncid::Integer,xtype::Integer,name,size,base_nc_typep,nfieldsp,classp)
-    check(ccall((:nc_inq_user_type,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint},Ptr{nc_type},Ptr{Cint},Ptr{Cint}),ncid,xtype,name,size,base_nc_typep,nfieldsp,classp))
+function nc_inq_user_type(
+    ncid::Integer,
+    xtype::Integer,
+    name,
+    size,
+    base_nc_typep,
+    nfieldsp,
+    classp,
+)
+    check(ccall(
+        (:nc_inq_user_type, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}, Ptr{nc_type}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        size,
+        base_nc_typep,
+        nfieldsp,
+        classp,
+    ))
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cvoid}),ncid,varid,name,xtype,len,op))
+function nc_put_att(ncid::Integer, varid::Integer, name, xtype::Integer, len::Integer, op)
+    check(ccall(
+        (:nc_put_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cvoid}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
 end
 
-function nc_get_att(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cvoid}),ncid,varid,name,ip))
+function nc_get_att(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
 end
 
-function nc_def_enum(ncid::Integer,base_typeid::Integer,name,typeidp)
-    check(ccall((:nc_def_enum,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{nc_type}),ncid,base_typeid,name,typeidp))
+function nc_def_enum(ncid::Integer, base_typeid::Integer, name, typeidp)
+    check(ccall(
+        (:nc_def_enum, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{nc_type}),
+        ncid,
+        base_typeid,
+        name,
+        typeidp,
+    ))
 end
 
-function nc_insert_enum(ncid::Integer,xtype::Integer,name,value)
-    check(ccall((:nc_insert_enum,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cvoid}),ncid,xtype,name,value))
+function nc_insert_enum(ncid::Integer, xtype::Integer, name, value)
+    check(ccall(
+        (:nc_insert_enum, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cvoid}),
+        ncid,
+        xtype,
+        name,
+        value,
+    ))
 end
 
-function nc_inq_enum(ncid::Integer,xtype::Integer,name,base_nc_typep,base_sizep,num_membersp)
-    check(ccall((:nc_inq_enum,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{nc_type},Ptr{Cint},Ptr{Cint}),ncid,xtype,name,base_nc_typep,base_sizep,num_membersp))
+function nc_inq_enum(
+    ncid::Integer,
+    xtype::Integer,
+    name,
+    base_nc_typep,
+    base_sizep,
+    num_membersp,
+)
+    check(ccall(
+        (:nc_inq_enum, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{nc_type}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        base_nc_typep,
+        base_sizep,
+        num_membersp,
+    ))
 end
 
-function nc_inq_enum_member(ncid::Integer,xtype::Integer,idx::Integer,name,value)
-    check(ccall((:nc_inq_enum_member,libnetcdf),Cint,(Cint,nc_type,Cint,Ptr{UInt8},Ptr{Cvoid}),ncid,xtype,idx,name,value))
+function nc_inq_enum_member(ncid::Integer, xtype::Integer, idx::Integer, name, value)
+    check(ccall(
+        (:nc_inq_enum_member, libnetcdf),
+        Cint,
+        (Cint, nc_type, Cint, Ptr{UInt8}, Ptr{Cvoid}),
+        ncid,
+        xtype,
+        idx,
+        name,
+        value,
+    ))
 end
 
-function nc_inq_enum_ident(ncid::Integer,xtype::Integer,value::Clonglong,identifier)
-    check(ccall((:nc_inq_enum_ident,libnetcdf),Cint,(Cint,nc_type,Clonglong,Ptr{UInt8}),ncid,xtype,value,identifier))
+function nc_inq_enum_ident(ncid::Integer, xtype::Integer, value::Clonglong, identifier)
+    check(ccall(
+        (:nc_inq_enum_ident, libnetcdf),
+        Cint,
+        (Cint, nc_type, Clonglong, Ptr{UInt8}),
+        ncid,
+        xtype,
+        value,
+        identifier,
+    ))
 end
 
-function nc_def_opaque(ncid::Integer,size::Integer,name,xtypep)
-    check(ccall((:nc_def_opaque,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type}),ncid,size,name,xtypep))
+function nc_def_opaque(ncid::Integer, size::Integer, name, xtypep)
+    check(ccall(
+        (:nc_def_opaque, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}),
+        ncid,
+        size,
+        name,
+        xtypep,
+    ))
 end
 
-function nc_inq_opaque(ncid::Integer,xtype::Integer,name,sizep)
-    check(ccall((:nc_inq_opaque,libnetcdf),Cint,(Cint,nc_type,Ptr{UInt8},Ptr{Cint}),ncid,xtype,name,sizep))
+function nc_inq_opaque(ncid::Integer, xtype::Integer, name, sizep)
+    check(ccall(
+        (:nc_inq_opaque, libnetcdf),
+        Cint,
+        (Cint, nc_type, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        xtype,
+        name,
+        sizep,
+    ))
 end
 
-function nc_put_var(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var,libnetcdf),Cint,(Cint,Cint,Ptr{Cvoid}),ncid,varid,op))
+function nc_put_var(ncid::Integer, varid::Integer, op)
+    check(ccall((:nc_put_var, libnetcdf), Cint, (Cint, Cint, Ptr{Cvoid}), ncid, varid, op))
 end
 
-function nc_get_var(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var,libnetcdf),Cint,(Cint,Cint,Ptr{Cvoid}),ncid,varid,ip))
+function nc_get_var(ncid::Integer, varid::Integer, ip)
+    check(ccall((:nc_get_var, libnetcdf), Cint, (Cint, Cint, Ptr{Cvoid}), ncid, varid, ip))
 end
 
-function nc_put_var1(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cvoid}),ncid,varid,indexp,op))
+function nc_put_var1(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
 end
 
-function nc_get_var1(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cvoid}),ncid,varid,indexp,ip))
+function nc_get_var1(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
 end
 
-function nc_put_vara(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,op))
+function nc_put_vara(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
 end
 
-function nc_get_vara(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,ip))
+function nc_get_vara(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
 end
 
-function nc_put_vars(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,op))
+function nc_put_vars(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
 end
 
-function nc_get_vars(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,ip))
+function nc_get_vars(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
 end
 
-function nc_put_varm(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,imapp,op))
+function nc_put_varm(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:nc_put_varm, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
 end
 
-function nc_get_varm(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,imapp,ip))
+function nc_get_varm(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:nc_get_varm, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
 end
 
-function nc_def_var_deflate(ncid::Integer,varid::Integer,shuffle::Integer,deflate::Integer,deflate_level::Integer)
-    check(ccall((:nc_def_var_deflate,libnetcdf),Cint,(Cint,Cint,Cint,Cint,Cint),ncid,varid,shuffle,deflate,deflate_level))
+function nc_def_var_deflate(
+    ncid::Integer,
+    varid::Integer,
+    shuffle::Integer,
+    deflate::Integer,
+    deflate_level::Integer,
+)
+    check(ccall(
+        (:nc_def_var_deflate, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Cint, Cint),
+        ncid,
+        varid,
+        shuffle,
+        deflate,
+        deflate_level,
+    ))
 end
 
-function nc_inq_var_deflate(ncid::Integer,varid::Integer,shufflep,deflatep,deflate_levelp)
-    check(ccall((:nc_inq_var_deflate,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,shufflep,deflatep,deflate_levelp))
+function nc_inq_var_deflate(
+    ncid::Integer,
+    varid::Integer,
+    shufflep,
+    deflatep,
+    deflate_levelp,
+)
+    check(ccall(
+        (:nc_inq_var_deflate, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        shufflep,
+        deflatep,
+        deflate_levelp,
+    ))
 end
 
-function nc_inq_var_szip(ncid::Integer,varid::Integer,options_maskp,pixels_per_blockp)
-    check(ccall((:nc_inq_var_szip,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint}),ncid,varid,options_maskp,pixels_per_blockp))
+function nc_inq_var_szip(ncid::Integer, varid::Integer, options_maskp, pixels_per_blockp)
+    check(ccall(
+        (:nc_inq_var_szip, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        options_maskp,
+        pixels_per_blockp,
+    ))
 end
 
-function nc_def_var_fletcher32(ncid::Integer,varid::Integer,fletcher32::Integer)
-    check(ccall((:nc_def_var_fletcher32,libnetcdf),Cint,(Cint,Cint,Cint),ncid,varid,fletcher32))
+function nc_def_var_fletcher32(ncid::Integer, varid::Integer, fletcher32::Integer)
+    check(ccall(
+        (:nc_def_var_fletcher32, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint),
+        ncid,
+        varid,
+        fletcher32,
+    ))
 end
 
-function nc_inq_var_fletcher32(ncid::Integer,varid::Integer,fletcher32p)
-    check(ccall((:nc_inq_var_fletcher32,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,fletcher32p))
+function nc_inq_var_fletcher32(ncid::Integer, varid::Integer, fletcher32p)
+    check(ccall(
+        (:nc_inq_var_fletcher32, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        fletcher32p,
+    ))
 end
 
-function nc_def_var_chunking(ncid::Integer,varid::Integer,storage::Integer,chunksizesp)
-    check(ccall((:nc_def_var_chunking,libnetcdf),Cint,(Cint,Cint,Cint,Ptr{Cint}),ncid,varid,storage,chunksizesp))
+function nc_def_var_chunking(ncid::Integer, varid::Integer, storage::Integer, chunksizesp)
+    check(ccall(
+        (:nc_def_var_chunking, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        storage,
+        chunksizesp,
+    ))
 end
 
-function nc_inq_var_chunking(ncid::Integer,varid::Integer,storagep,chunksizesp)
-    check(ccall((:nc_inq_var_chunking,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint}),ncid,varid,storagep,chunksizesp))
+function nc_inq_var_chunking(ncid::Integer, varid::Integer, storagep, chunksizesp)
+    check(ccall(
+        (:nc_inq_var_chunking, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        storagep,
+        chunksizesp,
+    ))
 end
 
-function nc_def_var_fill(ncid::Integer,varid::Integer,no_fill::Integer,fill_value)
-    check(ccall((:nc_def_var_fill,libnetcdf),Cint,(Cint,Cint,Cint,Ptr{Cvoid}),ncid,varid,no_fill,fill_value))
+function nc_def_var_fill(ncid::Integer, varid::Integer, no_fill::Integer, fill_value)
+    check(ccall(
+        (:nc_def_var_fill, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Ptr{Cvoid}),
+        ncid,
+        varid,
+        no_fill,
+        fill_value,
+    ))
 end
 
-function nc_inq_var_fill(ncid::Integer,varid::Integer,no_fill,fill_valuep)
-    check(ccall((:nc_inq_var_fill,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cvoid}),ncid,varid,no_fill,fill_valuep))
+function nc_inq_var_fill(ncid::Integer, varid::Integer, no_fill, fill_valuep)
+    check(ccall(
+        (:nc_inq_var_fill, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        no_fill,
+        fill_valuep,
+    ))
 end
 
-function nc_def_var_endian(ncid::Integer,varid::Integer,endian::Integer)
-    check(ccall((:nc_def_var_endian,libnetcdf),Cint,(Cint,Cint,Cint),ncid,varid,endian))
+function nc_def_var_endian(ncid::Integer, varid::Integer, endian::Integer)
+    check(ccall(
+        (:nc_def_var_endian, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint),
+        ncid,
+        varid,
+        endian,
+    ))
 end
 
-function nc_inq_var_endian(ncid::Integer,varid::Integer,endianp)
-    check(ccall((:nc_inq_var_endian,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,endianp))
+function nc_inq_var_endian(ncid::Integer, varid::Integer, endianp)
+    check(ccall(
+        (:nc_inq_var_endian, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        endianp,
+    ))
 end
 
-function nc_set_fill(ncid::Integer,fillmode::Integer,old_modep)
-    check(ccall((:nc_set_fill,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,fillmode,old_modep))
+function nc_set_fill(ncid::Integer, fillmode::Integer, old_modep)
+    check(ccall(
+        (:nc_set_fill, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        fillmode,
+        old_modep,
+    ))
 end
 
-function nc_set_default_format(format::Integer,old_formatp)
-    check(ccall((:nc_set_default_format,libnetcdf),Cint,(Cint,Ptr{Cint}),format,old_formatp))
+function nc_set_default_format(format::Integer, old_formatp)
+    check(ccall(
+        (:nc_set_default_format, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}),
+        format,
+        old_formatp,
+    ))
 end
 
-function nc_set_chunk_cache(size::Integer,nelems::Integer,preemption::Cfloat)
-    check(ccall((:nc_set_chunk_cache,libnetcdf),Cint,(Cint,Cint,Cfloat),size,nelems,preemption))
+function nc_set_chunk_cache(size::Integer, nelems::Integer, preemption::Cfloat)
+    check(ccall(
+        (:nc_set_chunk_cache, libnetcdf),
+        Cint,
+        (Cint, Cint, Cfloat),
+        size,
+        nelems,
+        preemption,
+    ))
 end
 
-function nc_get_chunk_cache(sizep,nelemsp,preemptionp)
-    check(ccall((:nc_get_chunk_cache,libnetcdf),Cint,(Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),sizep,nelemsp,preemptionp))
+function nc_get_chunk_cache(sizep, nelemsp, preemptionp)
+    check(ccall(
+        (:nc_get_chunk_cache, libnetcdf),
+        Cint,
+        (Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        sizep,
+        nelemsp,
+        preemptionp,
+    ))
 end
 
-function nc_set_var_chunk_cache(ncid::Integer,varid::Integer,size::Integer,nelems::Integer,preemption::Cfloat)
-    check(ccall((:nc_set_var_chunk_cache,libnetcdf),Cint,(Cint,Cint,Cint,Cint,Cfloat),ncid,varid,size,nelems,preemption))
+function nc_set_var_chunk_cache(
+    ncid::Integer,
+    varid::Integer,
+    size::Integer,
+    nelems::Integer,
+    preemption::Cfloat,
+)
+    check(ccall(
+        (:nc_set_var_chunk_cache, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Cint, Cfloat),
+        ncid,
+        varid,
+        size,
+        nelems,
+        preemption,
+    ))
 end
 
-function nc_get_var_chunk_cache(ncid::Integer,varid::Integer,sizep,nelemsp,preemptionp)
-    check(ccall((:nc_get_var_chunk_cache,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,sizep,nelemsp,preemptionp))
+function nc_get_var_chunk_cache(ncid::Integer, varid::Integer, sizep, nelemsp, preemptionp)
+    check(ccall(
+        (:nc_get_var_chunk_cache, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        sizep,
+        nelemsp,
+        preemptionp,
+    ))
 end
 
 function nc_redef(ncid::Integer)
-    check(ccall((:nc_redef,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:nc_redef, libnetcdf), Cint, (Cint,), ncid))
 end
 
-function nc__enddef(ncid::Integer,h_minfree::Integer,v_align::Integer,v_minfree::Integer,r_align::Integer)
-    check(ccall((:nc__enddef,libnetcdf),Cint,(Cint,Cint,Cint,Cint,Cint),ncid,h_minfree,v_align,v_minfree,r_align))
+function nc__enddef(
+    ncid::Integer,
+    h_minfree::Integer,
+    v_align::Integer,
+    v_minfree::Integer,
+    r_align::Integer,
+)
+    check(ccall(
+        (:nc__enddef, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Cint, Cint),
+        ncid,
+        h_minfree,
+        v_align,
+        v_minfree,
+        r_align,
+    ))
 end
 
 function nc_enddef(ncid::Integer)
-    check(ccall((:nc_enddef,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:nc_enddef, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function nc_sync(ncid::Integer)
-    check(ccall((:nc_sync,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:nc_sync, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function nc_abort(ncid::Integer)
-    check(ccall((:nc_abort,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:nc_abort, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function nc_close(ncid::Integer)
-    check(ccall((:nc_close,libnetcdf),Cint,(Cint,),ncid))
-end
-
-function nc_inq(ncid::Integer,ndimsp,nvarsp,nattsp,unlimdimidp)
-    check(ccall((:nc_inq,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,ndimsp,nvarsp,nattsp,unlimdimidp))
-end
-
-function nc_inq_ndims(ncid::Integer,ndimsp)
-    check(ccall((:nc_inq_ndims,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,ndimsp))
-end
-
-function nc_inq_nvars(ncid::Integer,nvarsp)
-    check(ccall((:nc_inq_nvars,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,nvarsp))
-end
-
-function nc_inq_natts(ncid::Integer,nattsp)
-    check(ccall((:nc_inq_natts,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,nattsp))
-end
-
-function nc_inq_unlimdim(ncid::Integer,unlimdimidp)
-    check(ccall((:nc_inq_unlimdim,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,unlimdimidp))
-end
-
-function nc_inq_unlimdims(ncid::Integer,nunlimdimsp,unlimdimidsp)
-    check(ccall((:nc_inq_unlimdims,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint}),ncid,nunlimdimsp,unlimdimidsp))
-end
-
-function nc_inq_format(ncid::Integer,formatp)
-    check(ccall((:nc_inq_format,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,formatp))
-end
-
-function nc_inq_format_extended(ncid::Integer,formatp,modep)
-    check(ccall((:nc_inq_format_extended,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint}),ncid,formatp,modep))
-end
-
-function nc_def_dim(ncid::Integer,name,len::Integer,idp)
-    check(ccall((:nc_def_dim,libnetcdf),Cint,(Cint,Ptr{UInt8},Cint,Ptr{Cint}),ncid,name,len,idp))
-end
-
-function nc_inq_dimid(ncid::Integer,name,idp)
-    check(ccall((:nc_inq_dimid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),ncid,name,idp))
-end
-
-function nc_inq_dim(ncid::Integer,dimid::Integer,name,lenp)
-    check(ccall((:nc_inq_dim,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cint}),ncid,dimid,name,lenp))
-end
-
-function nc_inq_dimname(ncid::Integer,dimid::Integer,name)
-    check(ccall((:nc_inq_dimname,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,dimid,name))
-end
-
-function nc_inq_dimlen(ncid::Integer,dimid::Integer,lenp)
-    check(ccall((:nc_inq_dimlen,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,dimid,lenp))
-end
-
-function nc_rename_dim(ncid::Integer,dimid::Integer,name)
-    check(ccall((:nc_rename_dim,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,dimid,name))
-end
-
-function nc_inq_att(ncid::Integer,varid::Integer,name,xtypep,lenp)
-    check(ccall((:nc_inq_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type},Ptr{Cint}),ncid,varid,name,xtypep,lenp))
-end
-
-function nc_inq_attid(ncid::Integer,varid::Integer,name,idp)
-    check(ccall((:nc_inq_attid,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cint}),ncid,varid,name,idp))
-end
-
-function nc_inq_atttype(ncid::Integer,varid::Integer,name,xtypep)
-    check(ccall((:nc_inq_atttype,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type}),ncid,varid,name,xtypep))
-end
-
-function nc_inq_attlen(ncid::Integer,varid::Integer,name,lenp)
-    check(ccall((:nc_inq_attlen,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cint}),ncid,varid,name,lenp))
-end
-
-function nc_inq_attname(ncid::Integer,varid::Integer,attnum::Integer,name)
-    check(ccall((:nc_inq_attname,libnetcdf),Cint,(Cint,Cint,Cint,Ptr{UInt8}),ncid,varid,attnum,name))
-end
-
-function nc_copy_att(ncid_in::Integer,varid_in::Integer,name,ncid_out::Integer,varid_out::Integer)
-    check(ccall((:nc_copy_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Cint,Cint),ncid_in,varid_in,name,ncid_out,varid_out))
-end
-
-function nc_rename_att(ncid::Integer,varid::Integer,name,newname)
-    check(ccall((:nc_rename_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt8}),ncid,varid,name,newname))
-end
-
-function nc_del_att(ncid::Integer,varid::Integer,name)
-    check(ccall((:nc_del_att,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,name))
-end
-
-function nc_put_att_text(ncid::Integer,varid::Integer,name,len::Integer,op)
-    check(ccall((:nc_put_att_text,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Cint,Ptr{UInt8}),ncid,varid,name,len,op))
-end
-
-function nc_get_att_text(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_text,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt8}),ncid,varid,name,ip))
-end
-
-function nc_put_att_string(ncid::Integer,varid::Integer,name,len::Integer,op)
-    check(ccall((:nc_put_att_string,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Cint,Ptr{Ptr{UInt8}}),ncid,varid,name,len,op))
-end
-
-function nc_get_att_string(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_string,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Ptr{UInt8}}),ncid,varid,name,ip))
-end
-
-function nc_put_att_uchar(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cuchar}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_uchar(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cuchar}),ncid,varid,name,ip))
-end
-
-function nc_put_att_schar(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_schar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{UInt8}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_schar(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_schar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt8}),ncid,varid,name,ip))
-end
-
-function nc_put_att_short(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_short,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Int16}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_short(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_short,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Int16}),ncid,varid,name,ip))
-end
-
-function nc_put_att_int(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_int,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cint}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_int(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_int,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cint}),ncid,varid,name,ip))
-end
-
-function nc_put_att_long(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_long,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Clong}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_long(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_long,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Clong}),ncid,varid,name,ip))
-end
-
-function nc_put_att_float(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_float,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cfloat}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_float(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_float,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cfloat}),ncid,varid,name,ip))
-end
-
-function nc_put_att_double(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_double,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cdouble}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_double(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_double,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cdouble}),ncid,varid,name,ip))
-end
-
-function nc_put_att_ushort(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{UInt16}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_ushort(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt16}),ncid,varid,name,ip))
-end
-
-function nc_put_att_uint(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_uint,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{UInt32}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_uint(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_uint,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt32}),ncid,varid,name,ip))
-end
-
-function nc_put_att_longlong(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Clonglong}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_longlong(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Clonglong}),ncid,varid,name,ip))
-end
-
-function nc_put_att_ulonglong(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Culonglong}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_ulonglong(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Culonglong}),ncid,varid,name,ip))
-end
-
-function nc_def_var(ncid::Integer,name,xtype::Integer,ndims::Integer,dimidsp,varidp)
-    check(ccall((:nc_def_var,libnetcdf),Cint,(Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cint},Ptr{Cint}),ncid,name,xtype,ndims,dimidsp,varidp))
-end
-
-function nc_inq_var(ncid::Integer,varid::Integer,name,xtypep,ndimsp,dimidsp,nattsp)
-    check(ccall((:nc_inq_var,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,name,xtypep,ndimsp,dimidsp,nattsp))
-end
-
-function nc_inq_varid(ncid::Integer,name,varidp)
-    check(ccall((:nc_inq_varid,libnetcdf),Cint,(Cint,Ptr{UInt8},Ptr{Cint}),ncid,name,varidp))
-end
-
-function nc_inq_varname(ncid::Integer,varid::Integer,name)
-    check(ccall((:nc_inq_varname,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,name))
-end
-
-function nc_inq_vartype(ncid::Integer,varid::Integer,xtypep)
-    check(ccall((:nc_inq_vartype,libnetcdf),Cint,(Cint,Cint,Ptr{nc_type}),ncid,varid,xtypep))
-end
-
-function nc_inq_varndims(ncid::Integer,varid::Integer,ndimsp)
-    check(ccall((:nc_inq_varndims,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,ndimsp))
-end
-
-function nc_inq_vardimid(ncid::Integer,varid::Integer,dimidsp)
-    check(ccall((:nc_inq_vardimid,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,dimidsp))
-end
-
-function nc_inq_varnatts(ncid::Integer,varid::Integer,nattsp)
-    check(ccall((:nc_inq_varnatts,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,nattsp))
-end
-
-function nc_rename_var(ncid::Integer,varid::Integer,name)
-    check(ccall((:nc_rename_var,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,name))
-end
-
-function nc_copy_var(ncid_in::Integer,varid::Integer,ncid_out::Integer)
-    check(ccall((:nc_copy_var,libnetcdf),Cint,(Cint,Cint,Cint),ncid_in,varid,ncid_out))
-end
-
-function nc_put_var1_text(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt8}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_text(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt8}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_uchar(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cuchar}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_uchar(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cuchar}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_schar(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt8}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_schar(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt8}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_short(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Int16}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_short(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Int16}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_int(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_int(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_long(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Clong}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_long(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Clong}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_float(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cfloat}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_float(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cfloat}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_double(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cdouble}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_double(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cdouble}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_ushort(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt16}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_ushort(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt16}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_uint(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt32}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_uint(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{UInt32}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_longlong(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Clonglong}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_longlong(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Clonglong}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_ulonglong(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Culonglong}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_ulonglong(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Culonglong}),ncid,varid,indexp,ip))
-end
-
-function nc_put_var1_string(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_string(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,indexp,ip))
-end
-
-function nc_put_vara_text(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_text(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_uchar(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_uchar(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_schar(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_schar(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_short(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_short(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_int(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_int(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_long(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_long(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_float(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_float(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_double(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_double(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_ushort(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_ushort(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_uint(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_uint(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_longlong(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_longlong(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_ulonglong(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_ulonglong(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vara_string(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_string(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vars_text(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_text(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_uchar(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_uchar(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_schar(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_schar(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_short(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_short(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_int(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_int(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_long(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_long(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_float(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_float(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_double(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_double(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_ushort(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_ushort(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_uint(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_uint(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_longlong(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_longlong(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_ulonglong(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_ulonglong(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_vars_string(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_string(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_varm_text(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_text(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_text,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_uchar(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_uchar(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_schar(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_schar(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_schar,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt8}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_short(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_short(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_short,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Int16}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_int(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_int(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_long(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_long(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_long,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_float(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_float(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cfloat}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_double(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_double(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cdouble}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_ushort(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_ushort(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt16}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_uint(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_uint(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_uint,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{UInt32}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_longlong(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_longlong(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Clonglong}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_ulonglong(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_ulonglong(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Culonglong}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_varm_string(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_string(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_string,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Ptr{UInt8}}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_var_text(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_text,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,op))
-end
-
-function nc_get_var_text(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_text,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,ip))
-end
-
-function nc_put_var_uchar(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cuchar}),ncid,varid,op))
-end
-
-function nc_get_var_uchar(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_uchar,libnetcdf),Cint,(Cint,Cint,Ptr{Cuchar}),ncid,varid,ip))
-end
-
-function nc_put_var_schar(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_schar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,op))
-end
-
-function nc_get_var_schar(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_schar,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,ip))
-end
-
-function nc_put_var_short(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_short,libnetcdf),Cint,(Cint,Cint,Ptr{Int16}),ncid,varid,op))
-end
-
-function nc_get_var_short(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_short,libnetcdf),Cint,(Cint,Cint,Ptr{Int16}),ncid,varid,ip))
-end
-
-function nc_put_var_int(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,op))
-end
-
-function nc_get_var_int(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_int,libnetcdf),Cint,(Cint,Cint,Ptr{Cint}),ncid,varid,ip))
-end
-
-function nc_put_var_long(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_long,libnetcdf),Cint,(Cint,Cint,Ptr{Clong}),ncid,varid,op))
-end
-
-function nc_get_var_long(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_long,libnetcdf),Cint,(Cint,Cint,Ptr{Clong}),ncid,varid,ip))
-end
-
-function nc_put_var_float(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cfloat}),ncid,varid,op))
-end
-
-function nc_get_var_float(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_float,libnetcdf),Cint,(Cint,Cint,Ptr{Cfloat}),ncid,varid,ip))
-end
-
-function nc_put_var_double(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cdouble}),ncid,varid,op))
-end
-
-function nc_get_var_double(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_double,libnetcdf),Cint,(Cint,Cint,Ptr{Cdouble}),ncid,varid,ip))
-end
-
-function nc_put_var_ushort(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{UInt16}),ncid,varid,op))
-end
-
-function nc_get_var_ushort(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_ushort,libnetcdf),Cint,(Cint,Cint,Ptr{UInt16}),ncid,varid,ip))
-end
-
-function nc_put_var_uint(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_uint,libnetcdf),Cint,(Cint,Cint,Ptr{UInt32}),ncid,varid,op))
-end
-
-function nc_get_var_uint(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_uint,libnetcdf),Cint,(Cint,Cint,Ptr{UInt32}),ncid,varid,ip))
-end
-
-function nc_put_var_longlong(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Clonglong}),ncid,varid,op))
-end
-
-function nc_get_var_longlong(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_longlong,libnetcdf),Cint,(Cint,Cint,Ptr{Clonglong}),ncid,varid,ip))
-end
-
-function nc_put_var_ulonglong(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Culonglong}),ncid,varid,op))
-end
-
-function nc_get_var_ulonglong(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_ulonglong,libnetcdf),Cint,(Cint,Cint,Ptr{Culonglong}),ncid,varid,ip))
-end
-
-function nc_put_var_string(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_string,libnetcdf),Cint,(Cint,Cint,Ptr{Ptr{UInt8}}),ncid,varid,op))
-end
-
-function nc_get_var_string(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_string,libnetcdf),Cint,(Cint,Cint,Ptr{Ptr{UInt8}}),ncid,varid,ip))
-end
-
-function nc_put_att_ubyte(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:nc_put_att_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cuchar}),ncid,varid,name,xtype,len,op))
-end
-
-function nc_get_att_ubyte(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:nc_get_att_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cuchar}),ncid,varid,name,ip))
-end
-
-function nc_put_var1_ubyte(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:nc_put_var1_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cuchar}),ncid,varid,indexp,op))
-end
-
-function nc_get_var1_ubyte(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:nc_get_var1_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cuchar}),ncid,varid,indexp,ip))
-end
-
-function nc_put_vara_ubyte(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:nc_put_vara_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,op))
-end
-
-function nc_get_vara_ubyte(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:nc_get_vara_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,ip))
-end
-
-function nc_put_vars_ubyte(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:nc_put_vars_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,op))
-end
-
-function nc_get_vars_ubyte(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:nc_get_vars_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,ip))
-end
-
-function nc_put_varm_ubyte(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:nc_put_varm_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,imapp,op))
-end
-
-function nc_get_varm_ubyte(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:nc_get_varm_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cuchar}),ncid,varid,startp,countp,stridep,imapp,ip))
-end
-
-function nc_put_var_ubyte(ncid::Integer,varid::Integer,op)
-    check(ccall((:nc_put_var_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cuchar}),ncid,varid,op))
-end
-
-function nc_get_var_ubyte(ncid::Integer,varid::Integer,ip)
-    check(ccall((:nc_get_var_ubyte,libnetcdf),Cint,(Cint,Cint,Ptr{Cuchar}),ncid,varid,ip))
+    check(ccall((:nc_close, libnetcdf), Cint, (Cint,), ncid))
+end
+
+function nc_inq(ncid::Integer, ndimsp, nvarsp, nattsp, unlimdimidp)
+    check(ccall(
+        (:nc_inq, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        ndimsp,
+        nvarsp,
+        nattsp,
+        unlimdimidp,
+    ))
+end
+
+function nc_inq_ndims(ncid::Integer, ndimsp)
+    check(ccall((:nc_inq_ndims, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, ndimsp))
+end
+
+function nc_inq_nvars(ncid::Integer, nvarsp)
+    check(ccall((:nc_inq_nvars, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, nvarsp))
+end
+
+function nc_inq_natts(ncid::Integer, nattsp)
+    check(ccall((:nc_inq_natts, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, nattsp))
+end
+
+function nc_inq_unlimdim(ncid::Integer, unlimdimidp)
+    check(ccall((:nc_inq_unlimdim, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, unlimdimidp))
+end
+
+function nc_inq_unlimdims(ncid::Integer, nunlimdimsp, unlimdimidsp)
+    check(ccall(
+        (:nc_inq_unlimdims, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        nunlimdimsp,
+        unlimdimidsp,
+    ))
+end
+
+function nc_inq_format(ncid::Integer, formatp)
+    check(ccall((:nc_inq_format, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, formatp))
+end
+
+function nc_inq_format_extended(ncid::Integer, formatp, modep)
+    check(ccall(
+        (:nc_inq_format_extended, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        formatp,
+        modep,
+    ))
+end
+
+function nc_def_dim(ncid::Integer, name, len::Integer, idp)
+    check(ccall(
+        (:nc_def_dim, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Cint, Ptr{Cint}),
+        ncid,
+        name,
+        len,
+        idp,
+    ))
+end
+
+function nc_inq_dimid(ncid::Integer, name, idp)
+    check(ccall(
+        (:nc_inq_dimid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        name,
+        idp,
+    ))
+end
+
+function nc_inq_dim(ncid::Integer, dimid::Integer, name, lenp)
+    check(ccall(
+        (:nc_inq_dim, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        dimid,
+        name,
+        lenp,
+    ))
+end
+
+function nc_inq_dimname(ncid::Integer, dimid::Integer, name)
+    check(ccall(
+        (:nc_inq_dimname, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        dimid,
+        name,
+    ))
+end
+
+function nc_inq_dimlen(ncid::Integer, dimid::Integer, lenp)
+    check(ccall(
+        (:nc_inq_dimlen, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        dimid,
+        lenp,
+    ))
+end
+
+function nc_rename_dim(ncid::Integer, dimid::Integer, name)
+    check(ccall(
+        (:nc_rename_dim, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        dimid,
+        name,
+    ))
+end
+
+function nc_inq_att(ncid::Integer, varid::Integer, name, xtypep, lenp)
+    check(ccall(
+        (:nc_inq_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        xtypep,
+        lenp,
+    ))
+end
+
+function nc_inq_attid(ncid::Integer, varid::Integer, name, idp)
+    check(ccall(
+        (:nc_inq_attid, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        idp,
+    ))
+end
+
+function nc_inq_atttype(ncid::Integer, varid::Integer, name, xtypep)
+    check(ccall(
+        (:nc_inq_atttype, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}),
+        ncid,
+        varid,
+        name,
+        xtypep,
+    ))
+end
+
+function nc_inq_attlen(ncid::Integer, varid::Integer, name, lenp)
+    check(ccall(
+        (:nc_inq_attlen, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        lenp,
+    ))
+end
+
+function nc_inq_attname(ncid::Integer, varid::Integer, attnum::Integer, name)
+    check(ccall(
+        (:nc_inq_attname, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        attnum,
+        name,
+    ))
+end
+
+function nc_copy_att(
+    ncid_in::Integer,
+    varid_in::Integer,
+    name,
+    ncid_out::Integer,
+    varid_out::Integer,
+)
+    check(ccall(
+        (:nc_copy_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Cint, Cint),
+        ncid_in,
+        varid_in,
+        name,
+        ncid_out,
+        varid_out,
+    ))
+end
+
+function nc_rename_att(ncid::Integer, varid::Integer, name, newname)
+    check(ccall(
+        (:nc_rename_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        newname,
+    ))
+end
+
+function nc_del_att(ncid::Integer, varid::Integer, name)
+    check(ccall(
+        (:nc_del_att, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+    ))
+end
+
+function nc_put_att_text(ncid::Integer, varid::Integer, name, len::Integer, op)
+    check(ccall(
+        (:nc_put_att_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_text(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_string(ncid::Integer, varid::Integer, name, len::Integer, op)
+    check(ccall(
+        (:nc_put_att_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Cint, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        name,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_string(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_uchar(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_uchar(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_schar(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_schar(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_short(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Int16}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_short(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Int16}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_int(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_int(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_long(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Clong}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_long(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Clong}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_float(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cfloat}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_float(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_double(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cdouble}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_double(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_ushort(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{UInt16}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_ushort(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt16}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_uint(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{UInt32}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_uint(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt32}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_longlong(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Clonglong}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_longlong(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_att_ulonglong(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Culonglong}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_ulonglong(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_def_var(ncid::Integer, name, xtype::Integer, ndims::Integer, dimidsp, varidp)
+    check(ccall(
+        (:nc_def_var, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        name,
+        xtype,
+        ndims,
+        dimidsp,
+        varidp,
+    ))
+end
+
+function nc_inq_var(ncid::Integer, varid::Integer, name, xtypep, ndimsp, dimidsp, nattsp)
+    check(ccall(
+        (:nc_inq_var, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        xtypep,
+        ndimsp,
+        dimidsp,
+        nattsp,
+    ))
+end
+
+function nc_inq_varid(ncid::Integer, name, varidp)
+    check(ccall(
+        (:nc_inq_varid, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, Ptr{Cint}),
+        ncid,
+        name,
+        varidp,
+    ))
+end
+
+function nc_inq_varname(ncid::Integer, varid::Integer, name)
+    check(ccall(
+        (:nc_inq_varname, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+    ))
+end
+
+function nc_inq_vartype(ncid::Integer, varid::Integer, xtypep)
+    check(ccall(
+        (:nc_inq_vartype, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{nc_type}),
+        ncid,
+        varid,
+        xtypep,
+    ))
+end
+
+function nc_inq_varndims(ncid::Integer, varid::Integer, ndimsp)
+    check(ccall(
+        (:nc_inq_varndims, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        ndimsp,
+    ))
+end
+
+function nc_inq_vardimid(ncid::Integer, varid::Integer, dimidsp)
+    check(ccall(
+        (:nc_inq_vardimid, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        dimidsp,
+    ))
+end
+
+function nc_inq_varnatts(ncid::Integer, varid::Integer, nattsp)
+    check(ccall(
+        (:nc_inq_varnatts, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        nattsp,
+    ))
+end
+
+function nc_rename_var(ncid::Integer, varid::Integer, name)
+    check(ccall(
+        (:nc_rename_var, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+    ))
+end
+
+function nc_copy_var(ncid_in::Integer, varid::Integer, ncid_out::Integer)
+    check(ccall(
+        (:nc_copy_var, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint),
+        ncid_in,
+        varid,
+        ncid_out,
+    ))
+end
+
+function nc_put_var1_text(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_text(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_uchar(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_uchar(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_schar(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_schar(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_short(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_short(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_int(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_int(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_long(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_long(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_float(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_float(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_double(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_double(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_ushort(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_ushort(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_uint(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_uint(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_longlong(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_longlong(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_ulonglong(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_ulonglong(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_var1_string(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_string(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_vara_text(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_text(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_uchar(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_uchar(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_schar(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_schar(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_short(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_short(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_int(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_int(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_long(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_long(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_float(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_float(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_double(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_double(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_ushort(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_ushort(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_uint(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_uint(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_longlong(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_longlong(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_ulonglong(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_ulonglong(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vara_string(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_string(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vars_text(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_text(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_uchar(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_uchar(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_schar(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_schar(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_short(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_short(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_int(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_int(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_long(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_long(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_float(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_float(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_double(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_double(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_ushort(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_ushort(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_uint(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_uint(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_longlong(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_longlong(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_ulonglong(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_ulonglong(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_vars_string(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_string(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_varm_text(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:nc_put_varm_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_text(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:nc_get_varm_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_uchar(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_uchar(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_schar(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_schar(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt8}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_short(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_short(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Int16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_int(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:nc_put_varm_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_int(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:nc_get_varm_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_long(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:nc_put_varm_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_long(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:nc_get_varm_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_float(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_float(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cfloat}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_double(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_double(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_ushort(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_ushort(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt16}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_uint(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:nc_put_varm_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_uint(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:nc_get_varm_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{UInt32}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_longlong(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_longlong(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Clonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_ulonglong(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_ulonglong(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Culonglong}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_varm_string(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_string(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_var_text(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_text(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_text, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_uchar(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_uchar(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_uchar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_schar(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_schar(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_schar, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_short(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Int16}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_short(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_short, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Int16}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_int(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_int(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_int, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_long(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_long(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_long, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_float(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cfloat}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_float(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_float, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cfloat}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_double(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cdouble}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_double(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_double, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cdouble}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_ushort(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt16}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_ushort(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_ushort, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt16}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_uint(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt32}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_uint(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_uint, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt32}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_longlong(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clonglong}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_longlong(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_longlong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clonglong}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_ulonglong(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Culonglong}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_ulonglong(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_ulonglong, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Culonglong}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_var_string(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_string(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_string, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Ptr{UInt8}}),
+        ncid,
+        varid,
+        ip,
+    ))
+end
+
+function nc_put_att_ubyte(
+    ncid::Integer,
+    varid::Integer,
+    name,
+    xtype::Integer,
+    len::Integer,
+    op,
+)
+    check(ccall(
+        (:nc_put_att_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
+end
+
+function nc_get_att_ubyte(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:nc_get_att_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
+end
+
+function nc_put_var1_ubyte(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:nc_put_var1_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
+end
+
+function nc_get_var1_ubyte(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:nc_get_var1_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
+end
+
+function nc_put_vara_ubyte(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:nc_put_vara_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
+end
+
+function nc_get_vara_ubyte(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:nc_get_vara_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
+end
+
+function nc_put_vars_ubyte(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:nc_put_vars_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
+end
+
+function nc_get_vars_ubyte(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:nc_get_vars_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
+end
+
+function nc_put_varm_ubyte(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    op,
+)
+    check(ccall(
+        (:nc_put_varm_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
+end
+
+function nc_get_varm_ubyte(
+    ncid::Integer,
+    varid::Integer,
+    startp,
+    countp,
+    stridep,
+    imapp,
+    ip,
+)
+    check(ccall(
+        (:nc_get_varm_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cuchar}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
+end
+
+function nc_put_var_ubyte(ncid::Integer, varid::Integer, op)
+    check(ccall(
+        (:nc_put_var_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        op,
+    ))
+end
+
+function nc_get_var_ubyte(ncid::Integer, varid::Integer, ip)
+    check(ccall(
+        (:nc_get_var_ubyte, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Cuchar}),
+        ncid,
+        varid,
+        ip,
+    ))
 end
 
 function nc_show_metadata(ncid::Integer)
-    check(ccall((:nc_show_metadata,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:nc_show_metadata, libnetcdf), Cint, (Cint,), ncid))
 end
 
-function nc__create_mp(path,cmode::Integer,initialsz::Integer,basepe::Integer,chunksizehintp,ncidp)
-    check(ccall((:nc__create_mp,libnetcdf),Cint,(Ptr{UInt8},Cint,Cint,Cint,Ptr{Cint},Ptr{Cint}),path,cmode,initialsz,basepe,chunksizehintp,ncidp))
+function nc__create_mp(
+    path,
+    cmode::Integer,
+    initialsz::Integer,
+    basepe::Integer,
+    chunksizehintp,
+    ncidp,
+)
+    check(ccall(
+        (:nc__create_mp, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        path,
+        cmode,
+        initialsz,
+        basepe,
+        chunksizehintp,
+        ncidp,
+    ))
 end
 
-function nc__open_mp(path,mode::Integer,basepe::Integer,chunksizehintp,ncidp)
-    check(ccall((:nc__open_mp,libnetcdf),Cint,(Ptr{UInt8},Cint,Cint,Ptr{Cint},Ptr{Cint}),path,mode,basepe,chunksizehintp,ncidp))
+function nc__open_mp(path, mode::Integer, basepe::Integer, chunksizehintp, ncidp)
+    check(ccall(
+        (:nc__open_mp, libnetcdf),
+        Cint,
+        (Ptr{UInt8}, Cint, Cint, Ptr{Cint}, Ptr{Cint}),
+        path,
+        mode,
+        basepe,
+        chunksizehintp,
+        ncidp,
+    ))
 end
 
 function nc_delete(path)
-    check(ccall((:nc_delete,libnetcdf),Cint,(Ptr{UInt8},),path))
+    check(ccall((:nc_delete, libnetcdf), Cint, (Ptr{UInt8},), path))
 end
 
-function nc_delete_mp(path,basepe::Integer)
-    check(ccall((:nc_delete_mp,libnetcdf),Cint,(Ptr{UInt8},Cint),path,basepe))
+function nc_delete_mp(path, basepe::Integer)
+    check(ccall((:nc_delete_mp, libnetcdf), Cint, (Ptr{UInt8}, Cint), path, basepe))
 end
 
-function nc_set_base_pe(ncid::Integer,pe::Integer)
-    check(ccall((:nc_set_base_pe,libnetcdf),Cint,(Cint,Cint),ncid,pe))
+function nc_set_base_pe(ncid::Integer, pe::Integer)
+    check(ccall((:nc_set_base_pe, libnetcdf), Cint, (Cint, Cint), ncid, pe))
 end
 
-function nc_inq_base_pe(ncid::Integer,pe)
-    check(ccall((:nc_inq_base_pe,libnetcdf),Cint,(Cint,Ptr{Cint}),ncid,pe))
+function nc_inq_base_pe(ncid::Integer, pe)
+    check(ccall((:nc_inq_base_pe, libnetcdf), Cint, (Cint, Ptr{Cint}), ncid, pe))
 end
 
 function nctypelen(datatype::Integer)
-    check(ccall((:nctypelen,libnetcdf),Cint,(nc_type,),datatype))
+    check(ccall((:nctypelen, libnetcdf), Cint, (nc_type,), datatype))
 end
 
-function nccreate(path,cmode::Integer)
-    check(ccall((:nccreate,libnetcdf),Cint,(Ptr{UInt8},Cint),path,cmode))
+function nccreate(path, cmode::Integer)
+    check(ccall((:nccreate, libnetcdf), Cint, (Ptr{UInt8}, Cint), path, cmode))
 end
 
-function ncopen(path,mode::Integer)
-    check(ccall((:ncopen,libnetcdf),Cint,(Ptr{UInt8},Cint),path,mode))
+function ncopen(path, mode::Integer)
+    check(ccall((:ncopen, libnetcdf), Cint, (Ptr{UInt8}, Cint), path, mode))
 end
 
-function ncsetfill(ncid::Integer,fillmode::Integer)
-    check(ccall((:ncsetfill,libnetcdf),Cint,(Cint,Cint),ncid,fillmode))
+function ncsetfill(ncid::Integer, fillmode::Integer)
+    check(ccall((:ncsetfill, libnetcdf), Cint, (Cint, Cint), ncid, fillmode))
 end
 
 function ncredef(ncid::Integer)
-    check(ccall((:ncredef,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:ncredef, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function ncendef(ncid::Integer)
-    check(ccall((:ncendef,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:ncendef, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function ncsync(ncid::Integer)
-    check(ccall((:ncsync,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:ncsync, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function ncabort(ncid::Integer)
-    check(ccall((:ncabort,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:ncabort, libnetcdf), Cint, (Cint,), ncid))
 end
 
 function ncclose(ncid::Integer)
-    check(ccall((:ncclose,libnetcdf),Cint,(Cint,),ncid))
+    check(ccall((:ncclose, libnetcdf), Cint, (Cint,), ncid))
 end
 
-function ncinquire(ncid::Integer,ndimsp,nvarsp,nattsp,unlimdimp)
-    check(ccall((:ncinquire,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,ndimsp,nvarsp,nattsp,unlimdimp))
+function ncinquire(ncid::Integer, ndimsp, nvarsp, nattsp, unlimdimp)
+    check(ccall(
+        (:ncinquire, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        ndimsp,
+        nvarsp,
+        nattsp,
+        unlimdimp,
+    ))
 end
 
-function ncdimdef(ncid::Integer,name,len::Clong)
-    check(ccall((:ncdimdef,libnetcdf),Cint,(Cint,Ptr{UInt8},Clong),ncid,name,len))
+function ncdimdef(ncid::Integer, name, len::Clong)
+    check(ccall((:ncdimdef, libnetcdf), Cint, (Cint, Ptr{UInt8}, Clong), ncid, name, len))
 end
 
-function ncdimid(ncid::Integer,name)
-    check(ccall((:ncdimid,libnetcdf),Cint,(Cint,Ptr{UInt8}),ncid,name))
+function ncdimid(ncid::Integer, name)
+    check(ccall((:ncdimid, libnetcdf), Cint, (Cint, Ptr{UInt8}), ncid, name))
 end
 
-function ncdiminq(ncid::Integer,dimid::Integer,name,lenp)
-    check(ccall((:ncdiminq,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Clong}),ncid,dimid,name,lenp))
+function ncdiminq(ncid::Integer, dimid::Integer, name, lenp)
+    check(ccall(
+        (:ncdiminq, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Clong}),
+        ncid,
+        dimid,
+        name,
+        lenp,
+    ))
 end
 
-function ncdimrename(ncid::Integer,dimid::Integer,name)
-    check(ccall((:ncdimrename,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,dimid,name))
+function ncdimrename(ncid::Integer, dimid::Integer, name)
+    check(ccall(
+        (:ncdimrename, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        dimid,
+        name,
+    ))
 end
 
-function ncattput(ncid::Integer,varid::Integer,name,xtype::Integer,len::Integer,op)
-    check(ccall((:ncattput,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cvoid}),ncid,varid,name,xtype,len,op))
+function ncattput(ncid::Integer, varid::Integer, name, xtype::Integer, len::Integer, op)
+    check(ccall(
+        (:ncattput, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cvoid}),
+        ncid,
+        varid,
+        name,
+        xtype,
+        len,
+        op,
+    ))
 end
 
-function ncattinq(ncid::Integer,varid::Integer,name,xtypep,lenp)
-    check(ccall((:ncattinq,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type},Ptr{Cint}),ncid,varid,name,xtypep,lenp))
+function ncattinq(ncid::Integer, varid::Integer, name, xtypep, lenp)
+    check(ccall(
+        (:ncattinq, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        xtypep,
+        lenp,
+    ))
 end
 
-function ncattget(ncid::Integer,varid::Integer,name,ip)
-    check(ccall((:ncattget,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{Cvoid}),ncid,varid,name,ip))
+function ncattget(ncid::Integer, varid::Integer, name, ip)
+    check(ccall(
+        (:ncattget, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        name,
+        ip,
+    ))
 end
 
-function ncattcopy(ncid_in::Integer,varid_in::Integer,name,ncid_out::Integer,varid_out::Integer)
-    check(ccall((:ncattcopy,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Cint,Cint),ncid_in,varid_in,name,ncid_out,varid_out))
+function ncattcopy(
+    ncid_in::Integer,
+    varid_in::Integer,
+    name,
+    ncid_out::Integer,
+    varid_out::Integer,
+)
+    check(ccall(
+        (:ncattcopy, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Cint, Cint),
+        ncid_in,
+        varid_in,
+        name,
+        ncid_out,
+        varid_out,
+    ))
 end
 
-function ncattname(ncid::Integer,varid::Integer,attnum::Integer,name)
-    check(ccall((:ncattname,libnetcdf),Cint,(Cint,Cint,Cint,Ptr{UInt8}),ncid,varid,attnum,name))
+function ncattname(ncid::Integer, varid::Integer, attnum::Integer, name)
+    check(ccall(
+        (:ncattname, libnetcdf),
+        Cint,
+        (Cint, Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        attnum,
+        name,
+    ))
 end
 
-function ncattrename(ncid::Integer,varid::Integer,name,newname)
-    check(ccall((:ncattrename,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{UInt8}),ncid,varid,name,newname))
+function ncattrename(ncid::Integer, varid::Integer, name, newname)
+    check(ccall(
+        (:ncattrename, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+        newname,
+    ))
 end
 
-function ncattdel(ncid::Integer,varid::Integer,name)
-    check(ccall((:ncattdel,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,name))
+function ncattdel(ncid::Integer, varid::Integer, name)
+    check(ccall((:ncattdel, libnetcdf), Cint, (Cint, Cint, Ptr{UInt8}), ncid, varid, name))
 end
 
-function ncvardef(ncid::Integer,name,xtype::Integer,ndims::Integer,dimidsp)
-    check(ccall((:ncvardef,libnetcdf),Cint,(Cint,Ptr{UInt8},nc_type,Cint,Ptr{Cint}),ncid,name,xtype,ndims,dimidsp))
+function ncvardef(ncid::Integer, name, xtype::Integer, ndims::Integer, dimidsp)
+    check(ccall(
+        (:ncvardef, libnetcdf),
+        Cint,
+        (Cint, Ptr{UInt8}, nc_type, Cint, Ptr{Cint}),
+        ncid,
+        name,
+        xtype,
+        ndims,
+        dimidsp,
+    ))
 end
 
-function ncvarid(ncid::Integer,name)
-    check(ccall((:ncvarid,libnetcdf),Cint,(Cint,Ptr{UInt8}),ncid,name))
+function ncvarid(ncid::Integer, name)
+    check(ccall((:ncvarid, libnetcdf), Cint, (Cint, Ptr{UInt8}), ncid, name))
 end
 
-function ncvarinq(ncid::Integer,varid::Integer,name,xtypep,ndimsp,dimidsp,nattsp)
-    check(ccall((:ncvarinq,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8},Ptr{nc_type},Ptr{Cint},Ptr{Cint},Ptr{Cint}),ncid,varid,name,xtypep,ndimsp,dimidsp,nattsp))
+function ncvarinq(ncid::Integer, varid::Integer, name, xtypep, ndimsp, dimidsp, nattsp)
+    check(ccall(
+        (:ncvarinq, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}, Ptr{nc_type}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
+        ncid,
+        varid,
+        name,
+        xtypep,
+        ndimsp,
+        dimidsp,
+        nattsp,
+    ))
 end
 
-function ncvarput1(ncid::Integer,varid::Integer,indexp,op)
-    check(ccall((:ncvarput1,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Cvoid}),ncid,varid,indexp,op))
+function ncvarput1(ncid::Integer, varid::Integer, indexp, op)
+    check(ccall(
+        (:ncvarput1, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        indexp,
+        op,
+    ))
 end
 
-function ncvarget1(ncid::Integer,varid::Integer,indexp,ip)
-    check(ccall((:ncvarget1,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Cvoid}),ncid,varid,indexp,ip))
+function ncvarget1(ncid::Integer, varid::Integer, indexp, ip)
+    check(ccall(
+        (:ncvarget1, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        indexp,
+        ip,
+    ))
 end
 
-function ncvarput(ncid::Integer,varid::Integer,startp,countp,op)
-    check(ccall((:ncvarput,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,op))
+function ncvarput(ncid::Integer, varid::Integer, startp, countp, op)
+    check(ccall(
+        (:ncvarput, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        op,
+    ))
 end
 
-function ncvarget(ncid::Integer,varid::Integer,startp,countp,ip)
-    check(ccall((:ncvarget,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,ip))
+function ncvarget(ncid::Integer, varid::Integer, startp, countp, ip)
+    check(ccall(
+        (:ncvarget, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        ip,
+    ))
 end
 
-function ncvarputs(ncid::Integer,varid::Integer,startp,countp,stridep,op)
-    check(ccall((:ncvarputs,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,op))
+function ncvarputs(ncid::Integer, varid::Integer, startp, countp, stridep, op)
+    check(ccall(
+        (:ncvarputs, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        op,
+    ))
 end
 
-function ncvargets(ncid::Integer,varid::Integer,startp,countp,stridep,ip)
-    check(ccall((:ncvargets,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,ip))
+function ncvargets(ncid::Integer, varid::Integer, startp, countp, stridep, ip)
+    check(ccall(
+        (:ncvargets, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        ip,
+    ))
 end
 
-function ncvarputg(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,op)
-    check(ccall((:ncvarputg,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,imapp,op))
+function ncvarputg(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, op)
+    check(ccall(
+        (:ncvarputg, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        op,
+    ))
 end
 
-function ncvargetg(ncid::Integer,varid::Integer,startp,countp,stridep,imapp,ip)
-    check(ccall((:ncvargetg,libnetcdf),Cint,(Cint,Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Cvoid}),ncid,varid,startp,countp,stridep,imapp,ip))
+function ncvargetg(ncid::Integer, varid::Integer, startp, countp, stridep, imapp, ip)
+    check(ccall(
+        (:ncvargetg, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid}),
+        ncid,
+        varid,
+        startp,
+        countp,
+        stridep,
+        imapp,
+        ip,
+    ))
 end
 
-function ncvarrename(ncid::Integer,varid::Integer,name)
-    check(ccall((:ncvarrename,libnetcdf),Cint,(Cint,Cint,Ptr{UInt8}),ncid,varid,name))
+function ncvarrename(ncid::Integer, varid::Integer, name)
+    check(ccall(
+        (:ncvarrename, libnetcdf),
+        Cint,
+        (Cint, Cint, Ptr{UInt8}),
+        ncid,
+        varid,
+        name,
+    ))
 end
 
-function ncrecinq(ncid::Integer,nrecvarsp,recvaridsp,recsizesp)
-    check(ccall((:ncrecinq,libnetcdf),Cint,(Cint,Ptr{Cint},Ptr{Cint},Ptr{Clong}),ncid,nrecvarsp,recvaridsp,recsizesp))
+function ncrecinq(ncid::Integer, nrecvarsp, recvaridsp, recsizesp)
+    check(ccall(
+        (:ncrecinq, libnetcdf),
+        Cint,
+        (Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Clong}),
+        ncid,
+        nrecvarsp,
+        recvaridsp,
+        recsizesp,
+    ))
 end
 
-function ncrecget(ncid::Integer,recnum::Clong,datap)
-    check(ccall((:ncrecget,libnetcdf),Cint,(Cint,Clong,Ptr{Ptr{Cvoid}}),ncid,recnum,datap))
+function ncrecget(ncid::Integer, recnum::Clong, datap)
+    check(ccall(
+        (:ncrecget, libnetcdf),
+        Cint,
+        (Cint, Clong, Ptr{Ptr{Cvoid}}),
+        ncid,
+        recnum,
+        datap,
+    ))
 end
 
-function ncrecput(ncid::Integer,recnum::Clong,datap)
-    check(ccall((:ncrecput,libnetcdf),Cint,(Cint,Clong,Ptr{Ptr{Cvoid}}),ncid,recnum,datap))
+function ncrecput(ncid::Integer, recnum::Clong, datap)
+    check(ccall(
+        (:ncrecput, libnetcdf),
+        Cint,
+        (Cint, Clong, Ptr{Ptr{Cvoid}}),
+        ncid,
+        recnum,
+        datap,
+    ))
 end

--- a/src/netcdf_helpers.jl
+++ b/src/netcdf_helpers.jl
@@ -26,38 +26,38 @@ end
 const funext = [
     (Float64, "double", "float64a"),
     (Float32, "float", "float32a"),
-    (Int32,   "int", "int32a"),
-    (UInt32,  "uint", "uint32a"),
-    (UInt8,   "uchar", "uint8a"),
-    (Int8,    "schar", "int8a"),
-    (Int16,   "short", "int16a"),
-    (UInt16,  "ushort", "uint16a"),
-    (Int64,   "longlong", "int64a"),
-    (UInt64,   "ulonglong", "uint64a"),
-    ]
+    (Int32, "int", "int32a"),
+    (UInt32, "uint", "uint32a"),
+    (UInt8, "uchar", "uint8a"),
+    (Int8, "schar", "int8a"),
+    (Int16, "short", "int16a"),
+    (UInt16, "ushort", "uint16a"),
+    (Int64, "longlong", "int64a"),
+    (UInt64, "ulonglong", "uint64a"),
+]
 
-const ida          = zeros(Int32,1)
-const namea        = zeros(UInt8,NC_MAX_NAME+1)
-const lengtha      = zeros(Csize_t,1)
-const dimida       = zeros(Int32,NC_MAX_VAR_DIMS)
-const chunk_sizea  = zeros(Csize_t,NC_MAX_VAR_DIMS)
-const storagep     = zeros(Int32,1)
-const ndima        = zeros(Int32,1)
-const nvara        = zeros(Int32,1)
-const ngatta       = zeros(Int32,1)
-const nunlimdimida = zeros(Int32,1)
-const typea        = zeros(Int32,1)
-const natta        = zeros(Int32,1)
-const nvals        = zeros(Csize_t,1)
-const dima         = zeros(Int32,1)
-const varida       = zeros(Int32,1)
-const vara         = zeros(Int32,1)
-const dumids       = zeros(Int32,NC_MAX_DIMS)
-const gstart       = zeros(UInt,NC_MAX_DIMS)
-const gcount       = zeros(UInt,NC_MAX_DIMS)
+const ida = zeros(Int32, 1)
+const namea = zeros(UInt8, NC_MAX_NAME + 1)
+const lengtha = zeros(Csize_t, 1)
+const dimida = zeros(Int32, NC_MAX_VAR_DIMS)
+const chunk_sizea = zeros(Csize_t, NC_MAX_VAR_DIMS)
+const storagep = zeros(Int32, 1)
+const ndima = zeros(Int32, 1)
+const nvara = zeros(Int32, 1)
+const ngatta = zeros(Int32, 1)
+const nunlimdimida = zeros(Int32, 1)
+const typea = zeros(Int32, 1)
+const natta = zeros(Int32, 1)
+const nvals = zeros(Csize_t, 1)
+const dima = zeros(Int32, 1)
+const varida = zeros(Int32, 1)
+const vara = zeros(Int32, 1)
+const dumids = zeros(Int32, NC_MAX_DIMS)
+const gstart = zeros(UInt, NC_MAX_DIMS)
+const gcount = zeros(UInt, NC_MAX_DIMS)
 
-for (t,ending,aname) in funext
-    @eval const $(Symbol(aname)) = zeros($t,1)
+for (t, ending, aname) in funext
+    @eval const $(Symbol(aname)) = zeros($t, 1)
 end
 
 """
@@ -66,14 +66,14 @@ end
 Convert a `ASCIIChar` array read from a NetCDF variable of type `NC_CHAR` to a Julia array of Strings
 """
 function nc_char2string(x::Array{ASCIIChar})
-  mapslices(x,dims=1) do r
-    i = findfirst(isequal(ASCIIChar(0)),r)
-    if i===nothing
-      String(r)
-    else
-      String(r[1:i-1])
-    end
-  end |> vec
+    mapslices(x, dims = 1) do r
+        i = findfirst(isequal(ASCIIChar(0)), r)
+        if i === nothing
+            String(r)
+        else
+            String(r[1:i-1])
+        end
+    end |> vec
 end
 
 """
@@ -83,69 +83,69 @@ Convert a Julia `String` array to an `Array{ASCIIChar}` so that it can be writte
 NetCDF variable of type `NC_CHAR`.
 """
 function nc_string2char(s::Array{String})
-    maxlen=maximum(length,s)
-    c = fill(ASCIIChar(0),maxlen+1,size(s)...)
-    for ii = eachindex(s)
-      for j = 1:length(s[ii])
-        cp = s[ii][j]
-        !isascii(cp) && error("Only ascii string can be written to NC_CHAR arrays.")
-        cp2 = ASCIIChar(UInt8(cp))
-        c[j,ii] = cp2
-      end
+    maxlen = maximum(length, s)
+    c = fill(ASCIIChar(0), maxlen + 1, size(s)...)
+    for ii in eachindex(s)
+        for j = 1:length(s[ii])
+            cp = s[ii][j]
+            !isascii(cp) && error("Only ascii string can be written to NC_CHAR arrays.")
+            cp2 = ASCIIChar(UInt8(cp))
+            c[j, ii] = cp2
+        end
     end
     c
 end
 
-function nc_open(fname::AbstractString,omode::UInt16)
+function nc_open(fname::AbstractString, omode::UInt16)
     # Function to open file fname, returns a NetCDF file ID
-    nc_open(fname,omode,ida)
+    nc_open(fname, omode, ida)
     return ida[1]
 end
 
-function nc_create(name,mode)
-    nc_create(name,mode,ida);
+function nc_create(name, mode)
+    nc_create(name, mode, ida)
     return ida[1]
 end
 
-function nc_inq_dim(id::Integer,idim::Integer)
+function nc_inq_dim(id::Integer, idim::Integer)
     # File to inquire dimension idimm returns dimension name and length
-    nc_inq_dim(id,idim,namea,lengtha)
-    namea[end]=0
-    name=unsafe_string(pointer(namea))
-    return (name,lengtha[1])
+    nc_inq_dim(id, idim, namea, lengtha)
+    namea[end] = 0
+    name = unsafe_string(pointer(namea))
+    return (name, lengtha[1])
 end
 
-function nc_inq_dimid(id::Integer,name::AbstractString)
+function nc_inq_dimid(id::Integer, name::AbstractString)
     # Function to read dimension id for a given function name
-    NetCDF.nc_inq_dimid(id,name,dimida)
+    NetCDF.nc_inq_dimid(id, name, dimida)
     return dimida[1]
 end
 
 function nc_redef(nc::NcFile)
     if (!nc.in_def_mode)
         nc_redef(nc.ncid)
-        nc.in_def_mode=true
+        nc.in_def_mode = true
     end
 end
 
 function nc_enddef(nc::NcFile)
     if nc.in_def_mode
         nc_enddef(nc.ncid)
-        nc.in_def_mode=false
+        nc.in_def_mode = false
     end
 end
 
 
 function nc_inq(id::Integer)
     # Inquire NetCDF file, return number of dims, number of variables, number of global attributes and number of unlimited dimensions
-    nc_inq(id,ndima,nvara,ngatta,nunlimdimida)
-    return (ndima[1],nvara[1],ngatta[1],nunlimdimida[1])
+    nc_inq(id, ndima, nvara, ngatta, nunlimdimida)
+    return (ndima[1], nvara[1], ngatta[1], nunlimdimida[1])
 end
 
 
 function nc_inq_attname(ncid::Integer, varid::Integer, attnum::Integer)
     # Get attribute name from attribute number
-    nc_inq_attname(ncid,varid,attnum,namea)
+    nc_inq_attname(ncid, varid, attnum, namea)
     namea[end] = 0
     name = unsafe_string(pointer(namea))
     return name
@@ -153,102 +153,205 @@ end
 
 function nc_get_att(ncid::Integer, varid::Integer, att::Union{Integer,AbstractString})
     #Reads attribute name, type and number of values
-    name = typeof(att)<:Integer ? nc_inq_attname(ncid,varid,att) : string(att)
-    nc_inq_att(ncid,varid,name,typea,nvals)
-    text = nc_get_att(ncid,varid,string(name),typea[1],nvals[1])
+    name = typeof(att) <: Integer ? nc_inq_attname(ncid, varid, att) : string(att)
+    nc_inq_att(ncid, varid, name, typea, nvals)
+    text = nc_get_att(ncid, varid, string(name), typea[1], nvals[1])
     return name, text
 end
 
 #Define methods for writing attributes
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Int8})    = nc_put_att_schar(ncid,varid,name,NC_BYTE,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{UInt8})   = nc_put_att_ubyte(ncid,varid,name,NC_UBYTE,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Int16})   = nc_put_att_short(ncid,varid,name,NC_SHORT,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{UInt16})  = nc_put_att_ushort(ncid,varid,name,NC_USHORT,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Int32})   = nc_put_att_int(ncid,varid,name,NC_INT,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{UInt32})  = nc_put_att_uint(ncid,varid,name,NC_UINT,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Int64})   = nc_put_att_longlong(ncid,varid,name,NC_INT64,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{UInt64})  = nc_put_att_ulonglong(ncid,varid,name,NC_UINT64,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Float32}) = nc_put_att_float(ncid,varid,name,NC_FLOAT,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Float64}) = nc_put_att_double(ncid,varid,name,NC_DOUBLE,length(val),val)
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Array{Any})     = error("Writing attribute array of type Any is not possible")
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Int8}) =
+    nc_put_att_schar(ncid, varid, name, NC_BYTE, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{UInt8}) =
+    nc_put_att_ubyte(ncid, varid, name, NC_UBYTE, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Int16}) =
+    nc_put_att_short(ncid, varid, name, NC_SHORT, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{UInt16}) =
+    nc_put_att_ushort(ncid, varid, name, NC_USHORT, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Int32}) =
+    nc_put_att_int(ncid, varid, name, NC_INT, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{UInt32}) =
+    nc_put_att_uint(ncid, varid, name, NC_UINT, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Int64}) =
+    nc_put_att_longlong(ncid, varid, name, NC_INT64, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{UInt64}) =
+    nc_put_att_ulonglong(ncid, varid, name, NC_UINT64, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Float32}) =
+    nc_put_att_float(ncid, varid, name, NC_FLOAT, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Float64}) =
+    nc_put_att_double(ncid, varid, name, NC_DOUBLE, length(val), val)
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Array{Any}) =
+    error("Writing attribute array of type Any is not possible")
 
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Int8) = begin int8a[1] = val; nc_put_att(ncid,varid,name,int8a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::UInt8) = begin uint8a[1] = val; nc_put_att(ncid,varid,name,uint8a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Int16) = begin int16a[1] = val; nc_put_att(ncid,varid,name,int16a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::UInt16) = begin uint16a[1] = val; nc_put_att(ncid,varid,name,uint16a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Int32) = begin int32a[1] = val; nc_put_att(ncid,varid,name,int32a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::UInt32) = begin uint32a[1] = val; nc_put_att(ncid,varid,name,uint32a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Int64) = begin int64a[1] = val; nc_put_att(ncid,varid,name,int64a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::UInt64) = begin uint64a[1] = val; nc_put_att(ncid,varid,name,uint64a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Float32) = begin float32a[1] = val; nc_put_att(ncid,varid,name,float32a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::Float64) = begin float64a[1] = val; nc_put_att(ncid,varid,name,float64a) end
-nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val) = error("Writing attribute of type $(typeof(val)) is currently not possible.")
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Int8) = begin
+    int8a[1] = val
+    nc_put_att(ncid, varid, name, int8a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::UInt8) = begin
+    uint8a[1] = val
+    nc_put_att(ncid, varid, name, uint8a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Int16) = begin
+    int16a[1] = val
+    nc_put_att(ncid, varid, name, int16a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::UInt16) = begin
+    uint16a[1] = val
+    nc_put_att(ncid, varid, name, uint16a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Int32) = begin
+    int32a[1] = val
+    nc_put_att(ncid, varid, name, int32a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::UInt32) = begin
+    uint32a[1] = val
+    nc_put_att(ncid, varid, name, uint32a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Int64) = begin
+    int64a[1] = val
+    nc_put_att(ncid, varid, name, int64a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::UInt64) = begin
+    uint64a[1] = val
+    nc_put_att(ncid, varid, name, uint64a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Float32) = begin
+    float32a[1] = val
+    nc_put_att(ncid, varid, name, float32a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val::Float64) = begin
+    float64a[1] = val
+    nc_put_att(ncid, varid, name, float64a)
+end
+nc_put_att(ncid::Integer, varid::Integer, name::AbstractString, val) =
+    error("Writing attribute of type $(typeof(val)) is currently not possible.")
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::AbstractString)
+function nc_put_att(
+    ncid::Integer,
+    varid::Integer,
+    name::AbstractString,
+    val::AbstractString,
+)
     val = string(val)
     len = sizeof(val)
-    nc_put_att_text(ncid,varid,name,len,val)
+    nc_put_att_text(ncid, varid, name, len, val)
 end
 
-function nc_put_att(ncid::Integer,varid::Integer,name::AbstractString,val::AbstractArray{String})
-    vals_p = map(x->pointer(x),val)
-    nc_put_att_string(ncid,varid,name,length(val),vals_p)
+function nc_put_att(
+    ncid::Integer,
+    varid::Integer,
+    name::AbstractString,
+    val::AbstractArray{String},
+)
+    vals_p = map(x -> pointer(x), val)
+    nc_put_att_string(ncid, varid, name, length(val), vals_p)
 end
 
-function nc_get_att(ncid::Integer,varid::Integer,name::AbstractString,attype::Integer,attlen::Integer)
+function nc_get_att(
+    ncid::Integer,
+    varid::Integer,
+    name::AbstractString,
+    attype::Integer,
+    attlen::Integer,
+)
     if attype == NC_CHAR
-        valsa = zeros(ASCIIChar,attlen+1)
-        nc_get_att_text(ncid,varid,name,valsa)
+        valsa = zeros(ASCIIChar, attlen + 1)
+        nc_get_att_text(ncid, varid, name, valsa)
         valsa[end] = ASCIIChar(0)
-        return String(valsa[1:findfirst(isequal(ASCIIChar(0)),valsa)-1])
+        return String(valsa[1:findfirst(isequal(ASCIIChar(0)), valsa)-1])
     else
-        valsa = Array{nctype2jltype[attype]}(undef,attlen)
-        return nc_get_att!(ncid,varid,name,valsa)
+        valsa = Array{nctype2jltype[attype]}(undef, attlen)
+        return nc_get_att!(ncid, varid, name, valsa)
     end
 end
 
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{UInt8}) = begin nc_get_att_ubyte(ncid,varid,name,valsa);valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Int8})  = begin nc_get_att_schar(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Int16})  = begin nc_get_att_short(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{UInt16})  = begin nc_get_att_ushort(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Int32})  = begin nc_get_att_int(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{UInt32})  = begin nc_get_att_uint(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Int64})  = begin nc_get_att_longlong(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{UInt64})  = begin nc_get_att_ulonglong(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Float32})  = begin nc_get_att_float(ncid,varid,name,valsa); valsa end
-nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{Float64})  = begin nc_get_att_double(ncid,varid,name,valsa); valsa end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{UInt8}) =
+    begin
+        nc_get_att_ubyte(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Int8}) = begin
+    nc_get_att_schar(ncid, varid, name, valsa)
+    valsa
+end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Int16}) =
+    begin
+        nc_get_att_short(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{UInt16}) =
+    begin
+        nc_get_att_ushort(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Int32}) =
+    begin
+        nc_get_att_int(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{UInt32}) =
+    begin
+        nc_get_att_uint(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Int64}) =
+    begin
+        nc_get_att_longlong(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{UInt64}) =
+    begin
+        nc_get_att_ulonglong(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Float32}) =
+    begin
+        nc_get_att_float(ncid, varid, name, valsa)
+        valsa
+    end
+nc_get_att!(ncid::Integer, varid::Integer, name::AbstractString, valsa::Array{Float64}) =
+    begin
+        nc_get_att_double(ncid, varid, name, valsa)
+        valsa
+    end
 
-function nc_get_att!(ncid::Integer,varid::Integer,name::AbstractString,valsa::Array{T,N}) where {T<:AbstractString,N}
+function nc_get_att!(
+    ncid::Integer,
+    varid::Integer,
+    name::AbstractString,
+    valsa::Array{T,N},
+) where {T<:AbstractString,N}
   #Assert that length of the attribute matches length of output
-  nc_inq_attlen(ncid, varid, name, lengtha)
-  @assert lengtha[1]==length(valsa)
-  valsa_c = Array{Ptr{UInt8}}(undef,length(valsa))
-  nc_get_att_string(ncid,varid,name,valsa_c)
-  for i = 1:length(valsa)
-    valsa[i] = unsafe_string(valsa_c[i])
-  end
-  nc_free_string(length(valsa_c),valsa_c)
-  valsa
+    nc_inq_attlen(ncid, varid, name, lengtha)
+    @assert lengtha[1] == length(valsa)
+    valsa_c = Array{Ptr{UInt8}}(undef, length(valsa))
+    nc_get_att_string(ncid, varid, name, valsa_c)
+    for i = 1:length(valsa)
+        valsa[i] = unsafe_string(valsa_c[i])
+    end
+    nc_free_string(length(valsa_c), valsa_c)
+    valsa
 end
 
-function nc_inq_var(nc::NcFile,varid::Integer)
+function nc_inq_var(nc::NcFile, varid::Integer)
     # Inquire variables in the file
-    nc_inq_var(nc.ncid,varid,namea,typea,ndima,dimida,natta)
+    nc_inq_var(nc.ncid, varid, namea, typea, ndima, dimida, natta)
     dimids = ndima[1] > 0 ? dimida[1:ndima[1]] : Int32[]
     namea[end] = 0
     name = unsafe_string(pointer(namea))
     #Find out chunks
-    nc_inq_var_chunking(nc.ncid,varid,storagep,chunk_sizea)
-    chunksize=storagep[1] == NC_CONTIGUOUS ? ntuple(i->0,ndima[1]) : ntuple(i->chunk_sizea[i],ndima[1])
-    return name, typea[1], dimids, natta[1], ndima[1], isdimvar(nc,name), chunksize
+    nc_inq_var_chunking(nc.ncid, varid, storagep, chunk_sizea)
+    chunksize = storagep[1] == NC_CONTIGUOUS ? ntuple(i -> 0, ndima[1]) :
+                ntuple(i -> chunk_sizea[i], ndima[1])
+    return name, typea[1], dimids, natta[1], ndima[1], isdimvar(nc, name), chunksize
 end
 
 #Test if a variable name is also a dimension name
 isdimvar(v::NcVar) = v.name == v.dim[1].name ? true : false
 
-function isdimvar(nc::NcFile,name::AbstractString)
+function isdimvar(nc::NcFile, name::AbstractString)
     for n in nc.dim
-        if n[2].name==name
+        if n[2].name == name
             return true
         end
     end
@@ -256,7 +359,7 @@ function isdimvar(nc::NcFile,name::AbstractString)
 end
 
 
-function getdimnamebyid(nc::NcFile,dimid::Integer)
+function getdimnamebyid(nc::NcFile, dimid::Integer)
     da = ""
     for d in nc.dim
         da = d[2].dimid == dimid ? d[2].name : da
@@ -269,7 +372,7 @@ function getatts_all(ncid::Integer, varid::Integer, natts::Integer)
     atts = Dict{Any,Any}()
     for attnum = 0:natts-1
         attname, attval = nc_get_att(ncid, varid, attnum)
-        if ((length(attval)==1) && !(typeof(attval)<:AbstractString))
+        if ((length(attval) == 1) && !(typeof(attval) <: AbstractString))
             attval = attval[1]
         end
         atts[attname] = attval
@@ -278,11 +381,15 @@ function getatts_all(ncid::Integer, varid::Integer, natts::Integer)
     return atts
 end
 
-function getatts(ncid::Integer, varid::Integer, attnames::Union{AbstractString,AbstractArray})
+function getatts(
+    ncid::Integer,
+    varid::Integer,
+    attnames::Union{AbstractString,AbstractArray},
+)
     atts = Dict{Any,Any}()
-    for aattname = (typeof(attnames)<:AbstractArray ? attnames : [attnames])
+    for aattname in (typeof(attnames) <: AbstractArray ? attnames : [attnames])
         attname, attval = nc_get_att(ncid, varid, aattname)
-        if ((length(attval)==1) && !(typeof(attval)<:AbstractString))
+        if ((length(attval) == 1) && !(typeof(attval) <: AbstractString))
             attval = attval[1]
         end
         atts[attname] = attval
@@ -294,7 +401,7 @@ end
 function readdimvars(nc::NcFile)
     for v in nc.vars
         if isdimvar(v[2])
-            v[2].dim[1].vals = readvar(nc,v[1])
+            v[2].dim[1].vals = readvar(nc, v[1])
             d[2].atts = v[2].atts
         end
     end
@@ -308,7 +415,7 @@ function checkboundsNC(v)
         if gstart[ci] + gcount[ci] > v.dim[i].dimlen
             if v.dim[i].unlim
                 #Reset length of unlimited dimension
-                v.dim[i].dimlen=gstart[ci] + gcount[ci]
+                v.dim[i].dimlen = gstart[ci] + gcount[ci]
             else
                 error("Start + Count exceeds dimension length in dimension $(v.dim[i].name)")
             end
@@ -325,7 +432,7 @@ function preparestartcount(start, count, v::NcVar)
     p = one(eltype(gcount))
     nd = length(start)
 
-    for i=1:nd
+    for i = 1:nd
         ci = nd + 1 - i
         gstart[ci] = start[i] - 1
         gcount[ci] = count[i] < 0 ? v.dim[i].dimlen - gstart[ci] : count[i]
@@ -342,8 +449,8 @@ function _readdimvars(nc::NcFile)
     for d in nc.dim
         for v in nc.vars
             if d[2].name == v[2].name
-                NC_VERBOSE && println(d[2].name," ",v[2].name)
-                d[2].vals = readvar(nc,v[2].name)
+                NC_VERBOSE && println(d[2].name, " ", v[2].name)
+                d[2].vals = readvar(nc, v[2].name)
                 d[2].atts = v[2].atts
             end
         end
@@ -357,7 +464,7 @@ defaultcount(v::NcVar) = Int[i for i in size(v)]
 
 
 function parsedimargs(dim)
-  isempty(dim) && return NcDim[]
+    isempty(dim) && return NcDim[]
     idim = 0
     dimlen = nothing
     dimvals = nothing
@@ -365,13 +472,13 @@ function parsedimargs(dim)
     name = nothing
     d = NcDim[]
     for a in dim
-        NC_VERBOSE && println(a,idim)
+        NC_VERBOSE && println(a, idim)
         if isa(a, AbstractString)
             #Assume a name is given
             #first create an NcDim object from the last dim
             if (name != nothing)
-                push!(d, finalizedim(dimlen,dimvals,dimatts,name))
-                idim = idim+1
+                push!(d, finalizedim(dimlen, dimvals, dimatts, name))
+                idim = idim + 1
                 dimlen = nothing
                 dimvals = nothing
                 dimatts = nothing
@@ -399,12 +506,13 @@ function parsedimargs(dim)
             end
         elseif isa(a, Dict)
             #Assume attributes are given
-            dimatts = dimatts == nothing ? a : error("Dimension attributes of $name defined more than once")
+            dimatts = dimatts == nothing ? a :
+                      error("Dimension attributes of $name defined more than once")
         else
             error("Could not parse argument $a in nccreate")
         end
     end
-    push!(d, finalizedim(dimlen,dimvals,dimatts,name))
+    push!(d, finalizedim(dimlen, dimvals, dimatts, name))
     return d
 end
 
@@ -413,11 +521,11 @@ function finalizedim(dimlen, dimvals, dimatts, name)
         dimlen = 1
     end
     if (dimlen != nothing) && (dimvals == nothing)
-        dimvals = Array{Float64}(undef,0)
+        dimvals = Array{Float64}(undef, 0)
     end
     if dimatts == nothing
-        dimatts = Dict("missval"=>-9999)
+        dimatts = Dict("missval" => -9999)
     end
     isunlimited = dimlen == 0 ? true : false
-    return NcDim(name, dimlen, atts=dimatts, values=dimvals, unlimited=isunlimited)
+    return NcDim(name, dimlen, atts = dimatts, values = dimvals, unlimited = isunlimited)
 end

--- a/test/array-like.jl
+++ b/test/array-like.jl
@@ -1,14 +1,14 @@
-NetCDF.open(fn1, "v1", mode=NC_WRITE) do v1
-  @test isa(v1, NetCDF.NcVar{Float64, 3, 6})
-  @test v1[1,1,1] == x1[1,1,1]
+NetCDF.open(fn1, "v1", mode = NC_WRITE) do v1
+    @test isa(v1, NetCDF.NcVar{Float64,3,6})
+    @test v1[1, 1, 1] == x1[1, 1, 1]
 
-  @test dropdims(v1[2,:,2],dims=(1,3)) == x1[2,:,2]
+    @test dropdims(v1[2, :, 2], dims = (1, 3)) == x1[2, :, 2]
 
-  @test dropdims(v1[:,3,1],dims=(2,3)) == x1[:,3,1]
-  inds = bitrand(size(x1))
-  @test v1[inds] == x1[inds]
+    @test dropdims(v1[:, 3, 1], dims = (2, 3)) == x1[:, 3, 1]
+    inds = bitrand(size(x1))
+    @test v1[inds] == x1[inds]
 
-  xnew = rand(Float64,size(x1))
-  v1[:,:,:] = xnew
-  @test v1 == xnew
+    xnew = rand(Float64, size(x1))
+    v1[:, :, :] = xnew
+    @test v1 == xnew
 end

--- a/test/chunks.jl
+++ b/test/chunks.jl
@@ -1,6 +1,6 @@
 #Tests for chunking
 cfn1 = tempname2()
-nccreate(cfn1, "v1", "d1", 10, "d2", 20, chunksize=(5,5))
+nccreate(cfn1, "v1", "d1", 10, "d2", 20, chunksize = (5, 5))
 ncwrite(rand(10, 20), cfn1, "v1")
 v = NetCDF.open(cfn1, "v1")
 @test v.chunksize == (5, 5)

--- a/test/high.jl
+++ b/test/high.jl
@@ -5,76 +5,111 @@ fn3 = tempname2()
 fn4 = tempname2()
 fn5 = tempname2()
 
-nccreate(fn1,"v1","Dim1",[1,2],Dict("units"=>"deg C"),"Dim2",collect(1:10),"Dim3",20,Dict("max"=>10),
-    mode=NC_NETCDF4)
-nccreate(fn1,"vstr","Dim2",collect(1:10),t=String)
-nccreate(fn1,"vchar","DimChar",20,"Dim2",t=NetCDF.NC_CHAR)
-nccreate(fn2,"v2","Dim1",[1,2,3],Dict("units"=>"deg C"),"Dim2",collect(1:10),"Dim3",20,Dict("max"=>10),
-atts = Dict("a1"=>"varatts"),gatts=Dict("Some global attributes"=>2010))
-nccreate(fn3,"v3","Dim1",3)
+nccreate(
+    fn1,
+    "v1",
+    "Dim1",
+    [1, 2],
+    Dict("units" => "deg C"),
+    "Dim2",
+    collect(1:10),
+    "Dim3",
+    20,
+    Dict("max" => 10),
+    mode = NC_NETCDF4,
+)
+nccreate(fn1, "vstr", "Dim2", collect(1:10), t = String)
+nccreate(fn1, "vchar", "DimChar", 20, "Dim2", t = NetCDF.NC_CHAR)
+nccreate(
+    fn2,
+    "v2",
+    "Dim1",
+    [1, 2, 3],
+    Dict("units" => "deg C"),
+    "Dim2",
+    collect(1:10),
+    "Dim3",
+    20,
+    Dict("max" => 10),
+    atts = Dict("a1" => "varatts"),
+    gatts = Dict("Some global attributes" => 2010),
+)
+nccreate(fn3, "v3", "Dim1", 3)
 for i = 1:length(tlist)
-    nccreate(fn3,"vt$i","Dim2",collect(1:10),t=tlist[i])
+    nccreate(fn3, "vt$i", "Dim2", collect(1:10), t = tlist[i])
 end
 
-ncputatt(fn1,"v1",Dict("Additional String attribute"=>"att"))
-ncputatt(fn1,"global",Dict("Additional global attribute"=>"gatt"))
-numberatts = Dict{Any,Any}("Additional $t attribute"=>t(20) for t in tlist)
+ncputatt(fn1, "v1", Dict("Additional String attribute" => "att"))
+ncputatt(fn1, "global", Dict("Additional global attribute" => "gatt"))
+numberatts = Dict{Any,Any}("Additional $t attribute" => t(20) for t in tlist)
 numberatts["Additional String attribute"] = "string attribute"
-arrayatts  = Dict{Any,Any}("Additional $t attribute"=>t[i for i in 1:20] for t in tlist)
-arrayatts["Additional String array attribute"] = String[string("string attribute ",i) for i in 1:20]
-ncputatt(fn1,"global",numberatts)
-ncputatt(fn1,"v1",arrayatts)
+arrayatts = Dict{Any,Any}("Additional $t attribute" => t[i for i = 1:20] for t in tlist)
+arrayatts["Additional String array attribute"] = String[string("string attribute ", i) for i = 1:20]
+ncputatt(fn1, "global", numberatts)
+ncputatt(fn1, "v1", arrayatts)
 
 #First generate the data
-x1 = rand(2,10,20)
-x2 = rand(2,10,20)
-xt = [rand(tl,10) for tl in tlist]
-xs = ["a","bb","ccc","dddd","eeeee","ffffff","ggggggg","hhhhhhhh","iiiiiiiii","jjjjjjjjjj"]
+x1 = rand(2, 10, 20)
+x2 = rand(2, 10, 20)
+xt = [rand(tl, 10) for tl in tlist]
+xs = [
+    "a",
+    "bb",
+    "ccc",
+    "dddd",
+    "eeeee",
+    "ffffff",
+    "ggggggg",
+    "hhhhhhhh",
+    "iiiiiiiii",
+    "jjjjjjjjjj",
+]
 #
 # And write it
 #
-ncwrite(x1,fn1,"v1")
+ncwrite(x1, fn1, "v1")
 #Test sequential writing along one dimension
 for i = 1:10
-  ncwrite(x2[:,i,:],fn2,"v2",start=[1,i,1],count=[-1,1,-1])
+    ncwrite(x2[:, i, :], fn2, "v2", start = [1, i, 1], count = [-1, 1, -1])
 end
-ncwrite(xs,fn1,"vstr")
-ncwrite(nc_string2char(xs),fn1,"vchar")
+ncwrite(xs, fn1, "vstr")
+ncwrite(nc_string2char(xs), fn1, "vchar")
 
 #Test automatic type conversion
-x4 = [1,2,3]
+x4 = [1, 2, 3]
 ncwrite(x4, fn3, "v3")
 
 for i = 1:length(tlist)
-  ncwrite(xt[i],fn3,"vt$i")
+    ncwrite(xt[i], fn3, "vt$i")
 end
 
 # Test creating unlimited dimension file
 nccreate(fn4, "myvar", "time", Inf)
 nccreate(fn4, "myvar2", "dinf", Inf, "d1", 10, "d2", 20)
 ncwrite(collect(1:10), fn4, "myvar")
-ncwrite(collect(1:5), fn4, "myvar", start=[11;])
-ncwrite(ones(5,10,20), fn4, "myvar2")
-ncwrite(zeros(1,10,20), fn4, "myvar2")
+ncwrite(collect(1:5), fn4, "myvar", start = [11;])
+ncwrite(ones(5, 10, 20), fn4, "myvar2")
+ncwrite(zeros(1, 10, 20), fn4, "myvar2")
 
 # Test reading existing files
-myvar2 = ones(5,10,20)
-myvar2[1,:,:] .= 0.0
+myvar2 = ones(5, 10, 20)
+myvar2[1, :, :] .= 0.0
 @test ncread(fn4, "myvar2") == myvar2
 @test nc_char2string(ncread(fn1, "vchar")) == xs
 @test_throws NetCDF.NetCDFError ncread("nonexistant file", "a var")
 
 # Test creating 0-dimensional variable
-nccreate(fn4,"scalar")
-a = Array{Float64,0}(undef);a[1]=10.0
-ncwrite(a,fn4,"scalar")
-@test ncread(fn4,"scalar")[1] == a[1]
+nccreate(fn4, "scalar")
+a = Array{Float64,0}(undef);
+a[1] = 10.0;
+ncwrite(a, fn4, "scalar")
+@test ncread(fn4, "scalar")[1] == a[1]
 
 # Test dimension variable type
-nccreate(fn5, "x5_1", "dim1", collect(Int32, 1:4), Dict("units"=>"m"))
-nccreate(fn5, "x5_2", "dim2", collect(Float32, 1:4), Dict("units"=>"m"))
-@test typeof(ncread(fn5, "dim1")) == Array{Int32, 1}
-@test typeof(ncread(fn5, "dim2")) == Array{Float32, 1}
+nccreate(fn5, "x5_1", "dim1", collect(Int32, 1:4), Dict("units" => "m"))
+nccreate(fn5, "x5_2", "dim2", collect(Float32, 1:4), Dict("units" => "m"))
+@test typeof(ncread(fn5, "dim1")) == Array{Int32,1}
+@test typeof(ncread(fn5, "dim2")) == Array{Float32,1}
 
 # Open file by reading and create new variable
 ncread(fn4, "myvar2")

--- a/test/intermediate.jl
+++ b/test/intermediate.jl
@@ -7,31 +7,31 @@ fn5 = tempname2()
 
 # Test Medium level Interface
 # Test Dimension Creation
-d1 = NcDim("Dim1",2;values=[5.0,10.0],atts=Dict("units"=>"deg C"));
-d2 = NcDim("Dim2",collect(1:10));
-d3 = NcDim("Dim3",20;atts=Dict("max"=>10));
-d4 = NcDim("DimUnlim",0,unlimited=true)
-d5 = NcDim("str_len",15)
+d1 = NcDim("Dim1", 2; values = [5.0, 10.0], atts = Dict("units" => "deg C"));
+d2 = NcDim("Dim2", collect(1:10));
+d3 = NcDim("Dim3", 20; atts = Dict("max" => 10));
+d4 = NcDim("DimUnlim", 0, unlimited = true)
+d5 = NcDim("str_len", 15)
 
 # Test Variable creation
-v1 = NcVar("v1",[d1,d2,d3],compress=5)  # With several dims in an Array, and compressed
-v2 = NcVar("v2",[d1,d2,d3],atts=Dict("a1"=>"varatts"))  # with given attributes
-v3 = NcVar("v3",d1)
-vs = NcVar("vstr",d2,t=String)
-vc = NcVar("vchar",[d5,d2],t=NetCDF.NC_CHAR)
-vscal = NcVar("vscal",NcDim[])
+v1 = NcVar("v1", [d1, d2, d3], compress = 5)  # With several dims in an Array, and compressed
+v2 = NcVar("v2", [d1, d2, d3], atts = Dict("a1" => "varatts"))  # with given attributes
+v3 = NcVar("v3", d1)
+vs = NcVar("vstr", d2, t = String)
+vc = NcVar("vchar", [d5, d2], t = NetCDF.NC_CHAR)
+vscal = NcVar("vscal", NcDim[])
 
-vt = Array{NcVar}(undef,length(tlist))
-for i= 1:length(tlist)
-      vt[i]=NcVar("vt$i",d2,t = tlist[i])
+vt = Array{NcVar}(undef, length(tlist))
+for i = 1:length(tlist)
+    vt[i] = NcVar("vt$i", d2, t = tlist[i])
 end
-vunlim = NcVar("vunlim",d4,t=Float64)
+vunlim = NcVar("vunlim", d4, t = Float64)
 
 
-numberatts = Dict{Any,Any}("Additional $t attribute"=>t(20) for t in tlist)
+numberatts = Dict{Any,Any}("Additional $t attribute" => t(20) for t in tlist)
 numberatts["Additional String attribute"] = "string attribute"
-arrayatts  = Dict{Any,Any}("Additional $t attribute"=>t[i for i in 1:20] for t in tlist)
-arrayatts["Additional String attribute"] = String[string("string attribute ",i) for i in 1:20]
+arrayatts = Dict{Any,Any}("Additional $t attribute" => t[i for i = 1:20] for t in tlist)
+arrayatts["Additional String attribute"] = String[string("string attribute ", i) for i = 1:20]
 
 
 
@@ -39,92 +39,120 @@ arrayatts["Additional String attribute"] = String[string("string attribute ",i) 
 #Test writing data
 #
 #First generate the data
-x1 = rand(2,10,20)
-x2 = rand(2,10,20)
-xt = [rand(tl,10) for tl in tlist]
-xs = ["a","bb","ccc","dddd","eeeee","ffffff","ggggggg","hhhhhhhh","iiiiiiiii","jjjjjjjjjj"]
-xscal = Array{Float64,0}(undef);xscal[1]=2.5
-x4 = [1,2]
+x1 = rand(2, 10, 20)
+x2 = rand(2, 10, 20)
+xt = [rand(tl, 10) for tl in tlist]
+xs = [
+    "a",
+    "bb",
+    "ccc",
+    "dddd",
+    "eeeee",
+    "ffffff",
+    "ggggggg",
+    "hhhhhhhh",
+    "iiiiiiiii",
+    "jjjjjjjjjj",
+]
+xscal = Array{Float64,0}(undef);
+xscal[1] = 2.5;
+x4 = [1, 2]
 #
 
 # Creating Files
-NetCDF.create(fn1,[v1,vs,vc],mode=NC_NETCDF4) do nc1
-  #Test Adding attributes
-  NetCDF.putatt(nc1,"v1",Dict("Additional String attribute"=>"att"))
-  NetCDF.putatt(nc1,"global",Dict("Additional global attribute"=>"gatt"))
-  NetCDF.putatt(nc1,"global",Dict("Additional Int8 attribute"=>Int8(20),
-  "Additional Int16 attribute"=>Int16(20),
-  "Additional Int32 attribute"=>Int32(20),
-  "Additional Float32 attribute"=>Float32(20),
-  "Additional Float64 attribute"=>Float64(20)))
-  NetCDF.putatt(nc1,"v1", Dict("Additional Int8 array attribute"=>Int8[i for i in 1:20],
-  "Additional Int16 array attribute"=>Int16[i for i in 1:20],
-  "Additional Int32 array attribute"=>Int32[i for i in 1:20],
-  "Additional Float32 array attribute"=>Float32[i for i in 1:20],
-  "Additional Float64 array attribute"=>Float64[i for i in 1:20]))
+NetCDF.create(fn1, [v1, vs, vc], mode = NC_NETCDF4) do nc1
+          #Test Adding attributes
+    NetCDF.putatt(nc1, "v1", Dict("Additional String attribute" => "att"))
+    NetCDF.putatt(nc1, "global", Dict("Additional global attribute" => "gatt"))
+    NetCDF.putatt(
+        nc1,
+        "global",
+        Dict(
+            "Additional Int8 attribute" => Int8(20),
+            "Additional Int16 attribute" => Int16(20),
+            "Additional Int32 attribute" => Int32(20),
+            "Additional Float32 attribute" => Float32(20),
+            "Additional Float64 attribute" => Float64(20),
+        ),
+    )
+    NetCDF.putatt(
+        nc1,
+        "v1",
+        Dict(
+            "Additional Int8 array attribute" => Int8[i for i = 1:20],
+            "Additional Int16 array attribute" => Int16[i for i = 1:20],
+            "Additional Int32 array attribute" => Int32[i for i = 1:20],
+            "Additional Float32 array attribute" => Float32[i for i = 1:20],
+            "Additional Float64 array attribute" => Float64[i for i = 1:20],
+        ),
+    )
 
-  #Test Adding attributes
-  NetCDF.putatt(nc1,"v1",Dict("Additional String attribute"=>"att"))
-  NetCDF.putatt(nc1,"global",Dict("Additional global attribute"=>"gatt"))
-  NetCDF.putatt(nc1,"global",numberatts)
-  NetCDF.putatt(nc1,"v1", arrayatts)
+          #Test Adding attributes
+    NetCDF.putatt(nc1, "v1", Dict("Additional String attribute" => "att"))
+    NetCDF.putatt(nc1, "global", Dict("Additional global attribute" => "gatt"))
+    NetCDF.putatt(nc1, "global", numberatts)
+    NetCDF.putatt(nc1, "v1", arrayatts)
 
-  NetCDF.putvar(nc1,"v1",x1)
-  NetCDF.putvar(nc1,"vstr",xs)
-  NetCDF.putvar(nc1,"vchar",nc_string2char(xs))
+    NetCDF.putvar(nc1, "v1", x1)
+    NetCDF.putvar(nc1, "vstr", xs)
+    NetCDF.putvar(nc1, "vchar", nc_string2char(xs))
 
 end
 
 
-NetCDF.create(fn2,NcVar[v2,v3,vscal],gatts=Dict("Some global attributes"=>2010)) do nc2
-  #Test sequential writing along one dimension
-  for i = 1:10
-    NetCDF.putvar(nc2,"v2",x2[:,i,:],start=[1,i,1],count=[-1,1,-1])
-  end
-  #Test automatic type conversion
-  NetCDF.putvar(nc2,"v3",x4)
+NetCDF.create(
+    fn2,
+    NcVar[v2, v3, vscal],
+    gatts = Dict("Some global attributes" => 2010),
+) do nc2
+    #Test sequential writing along one dimension
+    for i = 1:10
+        NetCDF.putvar(nc2, "v2", x2[:, i, :], start = [1, i, 1], count = [-1, 1, -1])
+    end
+    #Test automatic type conversion
+    NetCDF.putvar(nc2, "v3", x4)
 
-  NetCDF.putvar(nc2,"vscal",xscal)
+    NetCDF.putvar(nc2, "vscal", xscal)
 end
 
 
-NetCDF.create(fn3,vt) do nc3
-  for i=1:length(tlist)
-    NetCDF.putvar(nc3,"vt$i",xt[i])
-  end
+NetCDF.create(fn3, vt) do nc3
+    for i = 1:length(tlist)
+        NetCDF.putvar(nc3, "vt$i", xt[i])
+    end
 end
 
-NetCDF.create(fn4,vunlim) do ncunlim
-  NetCDF.putvar(ncunlim,"vunlim",collect(1:10))
+NetCDF.create(fn4, vunlim) do ncunlim
+    NetCDF.putvar(ncunlim, "vunlim", collect(1:10))
 end
 
 ##Read the data back and compare
-NetCDF.open(fn1,mode=NC_NOWRITE) do nc1
-  @test x1 == NetCDF.readvar(nc1,"v1")
-  @test xs == NetCDF.readvar(nc1,"vstr")
-  NetCDF.readvar(nc1,"v1",start=[1,1,1],count=[-1,-1,-1])
-  @test xs == NetCDF.nc_char2string(NetCDF.readvar(nc1,"vchar"))
+NetCDF.open(fn1, mode = NC_NOWRITE) do nc1
+    @test x1 == NetCDF.readvar(nc1, "v1")
+    @test xs == NetCDF.readvar(nc1, "vstr")
+    NetCDF.readvar(nc1, "v1", start = [1, 1, 1], count = [-1, -1, -1])
+    @test xs == NetCDF.nc_char2string(NetCDF.readvar(nc1, "vchar"))
 end
 
-NetCDF.open(fn2,mode=NC_NOWRITE) do nc2
-  @test x2 == NetCDF.readvar(nc2,"v2")
-  @test x4 == NetCDF.readvar(nc2,"v3")
-  @test xscal == NetCDF.readvar(nc2,"vscal")
+NetCDF.open(fn2, mode = NC_NOWRITE) do nc2
+    @test x2 == NetCDF.readvar(nc2, "v2")
+    @test x4 == NetCDF.readvar(nc2, "v3")
+    @test xscal == NetCDF.readvar(nc2, "vscal")
 end
 
 
 # #Test dimension variables type
-dim1 = NcDim("dim1", 4, atts=Dict("units" => "m"), values=collect(Int32,1:4))
-x5_1 = NcVar("x5_1", [dim1], atts=Dict("units" => "m"), t=Int32)
+dim1 = NcDim("dim1", 4, atts = Dict("units" => "m"), values = collect(Int32, 1:4))
+x5_1 = NcVar("x5_1", [dim1], atts = Dict("units" => "m"), t = Int32)
 
-dim2 = NcDim("dim2", 4, atts=Dict("units" => "m"), values=collect(Float32, 1:4))
-x5_2 = NcVar("x5_2", [dim2], atts=Dict("units" => "m"), t=Int32)
+dim2 = NcDim("dim2", 4, atts = Dict("units" => "m"), values = collect(Float32, 1:4))
+x5_2 = NcVar("x5_2", [dim2], atts = Dict("units" => "m"), t = Int32)
 
 
 NetCDF.create(fn5, [x5_1, x5_2]) do _
 end
 
 NetCDF.open(fn5) do nc5
-  @test typeof(NetCDF.readvar(nc5, "dim1")) == Array{Int32, 1}
-  @test typeof(NetCDF.readvar(nc5, "dim2")) == Array{Float32, 1}
+    @test typeof(NetCDF.readvar(nc5, "dim1")) == Array{Int32,1}
+    @test typeof(NetCDF.readvar(nc5, "dim2")) == Array{Float32,1}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ function tempname2()
     rm(f)
     f
 end
-tlist = [Int8, UInt8, Int16, UInt16, Int32,UInt32, Int64,UInt64, Float32, Float64]
+tlist = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64]
 
 @testset "NetCDF" begin
     include("intermediate.jl")


### PR DESCRIPTION
Done in Juno using the format button.

This was brought up a few times, but never made it into the code. Now seems like a fine time to do this.

Huge diff, but formatting only, no functional changes. In general I think this looks pretty good. Some of the ccalls in netcdf_c.jl are now a bit long, though they were hard to read before with many arguments on one line.
