### PR TITLE
fix: ulimited dimension

### DIFF
--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -134,6 +134,7 @@ function NcDim(
     unlimited = false,
 )
     length(values) > 0 &&
+    dimlength != 0 &&
     length(values) != dimlength &&
     error("Dimension value vector must have the same length as dimlength!")
     NcDim(-1, -1, -1, string(name), dimlength, collect(values), atts, unlimited)

--- a/src/netcdf_helpers.jl
+++ b/src/netcdf_helpers.jl
@@ -504,7 +504,9 @@ function parsedimargs(dim)
             #Assume dimension values are given
             if dimvals == nothing
                 dimvals = a
-                dimlen = length(dimvals)
+                if dimlen == nothing
+                    dimlen = length(dimvals)
+                end
             else
                 error("Dimension values of $name defined more than once")
             end


### PR DESCRIPTION
Support defining an unlimited dimension when the dimension values are given in the High-level
function `nccreate`.

An unlimited dimension `t` can now be defined by passing `0` to `nccreate` as follows.

```julia
using NetCDF

var = zeros(3, 4, 5); varattr = Dict("longname"=>"var")
xdim = collect(1:3); xdimattr = Dict("longname"=>"xdim")
ydim = collect(1:4); ydimattr = Dict("longname"=>"ydim")
t = collect(1:5); tattr = Dict("longname"=>"time")

nccreate(
    "foo.nc", "var",
    "xdim", xdim, xdimattr,
    "ydim", ydim, ydimattr,
    "t", 0, t, tattr;
    atts=varattr,
    t=NC_DOUBLE
)
ncwrite(var, "foo.nc", "var")
```