### PR TITLE
Use DiskArrays to implement AbstractArray interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
-  - 1.1
   - 1.2
+  - 1.3
   - nightly
 matrix:
   allow_failures:
@@ -20,7 +19,7 @@ notifications:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.1
+      julia: 1.3
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,14 @@ uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
 keywords = ["NetCDF", "IO"]
 license = "MIT"
 desc = "NetCDF file reading and writing"
-version = "0.8.2"
+version = "0.9.0"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
 CondaBinDeps = "a9693cdc-2bc8-5703-a9cd-1da358117377"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 
 [compat]
 BinDeps = "0.8.10, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 BinDeps = "0.8.10, 1.0"
 CondaBinDeps = "0.1.0"
 Formatting = "0.3.2, 0.4"
-julia = "1.0.0"
+julia = "1.2"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
-  - julia_version: 1.0
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:
@@ -9,9 +10,9 @@ platform:
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)
-# matrix:
-#   allow_failures:
-#   - julia_version: latest
+matrix:
+  allow_failures:
+  - julia_version: latest
 
 branches:
   only:

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -2,8 +2,8 @@ module NetCDF
 
 using Formatting
 using Base.Cartesian
-import DiskArrays: readblock!, writeblock!, AbstractDiskArray
-
+import DiskArrays: readblock!, writeblock!, AbstractDiskArray, eachchunk, GridChunks,
+       estimate_chunksize
 
 include("netcdf_c.jl")
 
@@ -219,6 +219,13 @@ function readblock!(v::NcVar, aout, r...)
 end
 function writeblock!(v::NcVar, a, r...)
   putvar(v,a,start = [first(i) for i in r], count = [length(i) for i in r])
+end
+function eachchunk(v::NcVar)
+  if all(iszero,v.chunksize)
+    GridChunks(v, estimate_chunksize(v))
+  else
+    GridChunks(v, map(Int64,v.chunksize))
+  end
 end
 
 """

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -2,6 +2,8 @@ module NetCDF
 
 using Formatting
 using Base.Cartesian
+import DiskArrays: readblock!, writeblock!, AbstractDiskArray
+
 
 include("netcdf_c.jl")
 
@@ -169,7 +171,7 @@ will work for reading and writing data to and from a NetCDF file. `NcVar` object
 indexing an `NcFile` object (e.g. `myfile["temperature"]`) or, when creating a new file, by its constructor. The type parameter `M`
 denotes the NetCDF data type of the variable, which may or may not correspond to the Julia Data Type.
 """
-mutable struct NcVar{T,N,M} <: AbstractArray{T,N}
+mutable struct NcVar{T,N,M} <: AbstractDiskArray{T,N}
     ncid::Int32
     varid::Int32
     ndim::Int32
@@ -209,6 +211,15 @@ Base.convert(::Type{NcVar{T}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
     v.compress,
     v.chunksize,
 )
+
+
+# Implement the DiskArrays interface
+function readblock!(v::NcVar, aout, r...)
+  readvar!(v,aout,start = [first(i) for i in r], count = [length(i) for i in r])
+end
+function writeblock!(v::NcVar, a, r...)
+  putvar(v,a,start = [first(i) for i in r], count = [length(i) for i in r])
+end
 
 """
     NcVar(name::AbstractString,dimin::Union{NcDim,Array{NcDim,1}}
@@ -253,54 +264,6 @@ end
 end
 const IndR = Union{Integer,UnitRange,Colon}
 const ArNum = Union{AbstractArray,Number}
-
-IndexStyle(::NcVar) = IndexCartesian()
-Base.getindex(v::NcVar{T,0}) where {T} = readvar(v)
-Base.getindex(v::NcVar{T,1}, i1::IndR) where {T} = readvar(v, i1)
-Base.getindex(v::NcVar{T,2}, i1::IndR, i2::IndR) where {T} = readvar(v, i1, i2)
-Base.getindex(v::NcVar{T,3}, i1::IndR, i2::IndR, i3::IndR) where {T} =
-    readvar(v, i1, i2, i3)
-Base.getindex(v::NcVar{T,4}, i1::IndR, i2::IndR, i3::IndR, i4::IndR) where {T} =
-    readvar(v, i1, i2, i3, i4)
-Base.getindex(v::NcVar{T,5}, i1::IndR, i2::IndR, i3::IndR, i4::IndR, i5::IndR) where {T} =
-    readvar(v, i1, i2, i3, i4, i5)
-Base.getindex(
-    v::NcVar{T,6},
-    i1::IndR,
-    i2::IndR,
-    i3::IndR,
-    i4::IndR,
-    i5::IndR,
-    i6::IndR,
-) where {T} = readvar(v, i1, i2, i3, i4, i5, i6)
-
-Base.setindex!(v::NcVar{T,0}, x::ArNum) where {T} = putvar(v, x)
-Base.setindex!(v::NcVar{T,1}, x::ArNum, i1::IndR) where {T} = putvar(v, x, i1)
-Base.setindex!(v::NcVar{T,2}, x::ArNum, i1::IndR, i2::IndR) where {T} = putvar(v, x, i1, i2)
-Base.setindex!(v::NcVar{T,3}, x::ArNum, i1::IndR, i2::IndR, i3::IndR) where {T} =
-    putvar(v, x, i1, i2, i3)
-Base.setindex!(v::NcVar{T,4}, x::ArNum, i1::IndR, i2::IndR, i3::IndR, i4::IndR) where {T} =
-    putvar(v, x, i1, i2, i3, i4)
-Base.setindex!(
-    v::NcVar{T,5},
-    x::ArNum,
-    i1::IndR,
-    i2::IndR,
-    i3::IndR,
-    i4::IndR,
-    i5::IndR,
-) where {T} = putvar(v, x, i1, i2, i3, i4, i5)
-Base.setindex!(
-    v::NcVar{T,6},
-    x::ArNum,
-    i1::IndR,
-    i2::IndR,
-    i3::IndR,
-    i4::IndR,
-    i5::IndR,
-    i6::IndR,
-) where {T} = putvar(v, x, i1, i2, i3, i4, i5, i6)
-
 
 """
     NcFile

--- a/test/array-like.jl
+++ b/test/array-like.jl
@@ -2,13 +2,13 @@ NetCDF.open(fn1, "v1", mode = NC_WRITE) do v1
     @test isa(v1, NetCDF.NcVar{Float64,3,6})
     @test v1[1, 1, 1] == x1[1, 1, 1]
 
-    @test dropdims(v1[2, :, 2], dims = (1, 3)) == x1[2, :, 2]
+  @test v1[2,:,2] == x1[2,:,2]
 
-    @test dropdims(v1[:, 3, 1], dims = (2, 3)) == x1[:, 3, 1]
-    inds = bitrand(size(x1))
-    @test v1[inds] == x1[inds]
+  @test v1[:,3,1] == x1[:,3,1]
+  inds = bitrand(size(x1))
+  @test v1[inds] == x1[inds]
 
-    xnew = rand(Float64, size(x1))
-    v1[:, :, :] = xnew
-    @test v1 == xnew
+  xnew = rand(Float64,size(x1))
+  v1[:,:,:] = xnew
+  @test v1[:,:,:] == xnew
 end


### PR DESCRIPTION
As a first test for the `DiskArrays` package, this branch makes `NcVar` a subtype of `AbstractDiskArray` and gets the indexing behavior from there. This would be breaking, since it will modify the indexing behavior to be more consistent with Julia Base. 

This is still work in progress and can only be merged when DiskArrays is registered, but I think it would be good to have a placeholder PR already. 

Fixes #113