### PR TITLE
Add Finalizers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
 keywords = ["NetCDF", "IO"]
 license = "MIT"
 desc = "NetCDF file reading and writing"
-version = "0.9.0"
+version = "0.10.0"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
 [compat]
 BinDeps = "0.8.10, 1.0"
 CondaBinDeps = "0.1.0, 0.2"
-DiskArrays = "0.1"
+DiskArrays = "0.2"
 Formatting = "0.3.2, 0.4"
 julia = "1.2"
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ attribs  = Dict("units"   => "mm/d",
 ```
 
  Creating variables and files is done by using the nccreate command:
- 
+
 ```julia
 nccreate(filename, varname, "x1", collect(11:20), "t", 20, Dict("units"=>"s"), atts=attribs)
 ```
@@ -66,9 +66,19 @@ The full documentation can be found [here][docs-dev-url]
 
 An alternative interface for reading NetCDF files can be found here: https://github.com/Alexander-Barth/NCDatasets.jl
 
+# DiskArray interface
+
+As of version 0.9 we provide an interface to DiskArrays.jl, which lets you treat NetCDF variables as Julia AbstractArrays. Special methods for accessing, reading slices and reductions and broadcasting are implemented, so that working with the arrays should be efficient.
+
+So the following returns a lazy AbstractArray container referencing the data in the variable.
+
+```julia
+v = NetCDF.open(filename, varname)
+```
+
 ## Credits
 
-This package was originally started and is mostly maintained by Fabian Gans (fgans@bgc-jena.mpg.de). The automatic C wrapper generator was contributed by Martijn Visser (https://github.com/visr). Many thanks to several people who contributed bug fixes and enhancements. 
+This package was originally started and is mostly maintained by Fabian Gans (fgans@bgc-jena.mpg.de). The automatic C wrapper generator was contributed by Martijn Visser (https://github.com/visr). Many thanks to several people who contributed bug fixes and enhancements.
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://JuliaGeo.github.io/NetCDF.jl/dev

--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -50,9 +50,7 @@ Here, filename is the name of the file to be created and varlist an array of `Nc
 
 ## Miscellaneous
 
-once you have finished reading, writing or editing your files you can close the file with
-
-    NetCDF.close(nc)
+Note that as of version 0.9 there is no need to close the NetCDF files anymore. This will be done through finalizers.
 
 If you just want to synchronize your changes to the disk, run
 
@@ -61,8 +59,7 @@ If you just want to synchronize your changes to the disk, run
 where `nc` is a NetCDF file handle.
 
 As an alternative, `NetCDF.open` and `NetCDF.create` provide a method accepting a
-function as its first argument. This can be used to make sure the file always get
-properly closed, even if an error occurs while working with the handle. 
+function as its first argument.
 
 ## Interface for creating files
 

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -860,14 +860,16 @@ create(
 
 closes a NetCDF file handle
 """
-function _close(nco::NcFile)
+function _close(nco::Union{NcFile, NcVar})
     #Close file
     nc_close(nco.ncid)
     nothing
 end
 
-close(x::Union{NcFile, NcVar}) = @warn "NetCDF.close is deprecated, since closing files is done with finalizers from now on. "
-
+function close(x::Union{NcFile, NcVar})
+  println(stacktrace())
+  @warn "NetCDF.close is deprecated, since closing files is done with finalizers from now on. "
+end
 
 """
     NetCDF.open(fil::AbstractString,v::AbstractString)
@@ -994,7 +996,7 @@ function open(f::Function, args...; kwargs...)
     try
         f(io)
     finally
-        close(io)
+        _close(io)
     end
 end
 
@@ -1015,7 +1017,7 @@ function create(f::Function, args...; kwargs...)
     try
         f(io)
     finally
-        close(io)
+        _close(io)
     end
 end
 

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -222,6 +222,7 @@ function readblock!(v::NcVar, aout, r::AbstractUnitRange...)
 end
 function writeblock!(v::NcVar, a, r::AbstractUnitRange...)
   putvar(v,a,start = [first(i) for i in r], count = [length(i) for i in r])
+  sync(v.ncfile)
 end
 getchunksize(v::NcVar) = getchunksize(haschunks(v),v)
 getchunksize(::Chunked, v::NcVar) = map(Int64,v.chunksize)

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -217,10 +217,10 @@ Base.convert(::Type{NcVar{T}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
 
 
 # Implement the DiskArrays interface
-function readblock!(v::NcVar, aout, r...)
+function readblock!(v::NcVar, aout, r::AbstractUnitRange...)
   readvar!(v,aout,start = [first(i) for i in r], count = [length(i) for i in r])
 end
-function writeblock!(v::NcVar, a, r...)
+function writeblock!(v::NcVar, a, r::AbstractUnitRange...)
   putvar(v,a,start = [first(i) for i in r], count = [length(i) for i in r])
 end
 getchunksize(v::NcVar) = getchunksize(haschunks(v),v)
@@ -868,7 +868,7 @@ end
 
 function close(x::Union{NcFile, NcVar})
   println(stacktrace())
-  @warn "NetCDF.close is deprecated, since closing files is done with finalizers from now on. "
+  @warn "NetCDF.close is deprecated, because closing files is done with finalizers from now on. "
 end
 
 """

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -183,6 +183,7 @@ mutable struct NcVar{T,N,M} <: AbstractDiskArray{T,N}
     atts::Dict
     compress::Int32
     chunksize::NTuple{N,Int32}
+    ncfile #Kept to prevent closing through finalizer
 end
 
 Base.convert(::Type{NcVar{T,N,M}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
@@ -197,6 +198,7 @@ Base.convert(::Type{NcVar{T,N,M}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,
     v.atts,
     v.compress,
     v.chunksize,
+    v.ncfile,
 )
 Base.convert(::Type{NcVar{T}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
     v.ncid,
@@ -210,6 +212,7 @@ Base.convert(::Type{NcVar{T}}, v::NcVar{S,N,M}) where {S,T,N,M} = NcVar{T,N,M}(
     v.atts,
     v.compress,
     v.chunksize,
+    v.ncfile
 )
 
 
@@ -260,6 +263,7 @@ function NcVar(
         atts,
         Int32(compress),
         chunksize,
+        nothing,
     )
 end
 
@@ -757,6 +761,7 @@ function create(
     varlist::Array{<:NcVar};
     gatts::Dict = Dict{Any,Any}(),
     mode::UInt16 = NC_NETCDF4,
+    add_finalizer = true,
 )
 
     #Create the file
@@ -810,6 +815,7 @@ function create(
                     d.atts,
                     -1,
                     (zero(Int32),),
+                    nc
                 ),
             )
         end
@@ -818,6 +824,7 @@ function create(
     # Create variables in the file
     for v in varlist
         create_var(nc, v, mode)
+        v.ncfile = nc
     end
 
     # Put global attributes
@@ -835,7 +842,9 @@ function create(
         end
     end
 
-    return (nc)
+    add_finalizer && finalizer(close,nc)
+
+    return nc
 end
 
 create(
@@ -843,7 +852,8 @@ create(
     varlist::NcVar...;
     gatts::Dict = Dict{Any,Any}(),
     mode::UInt16 = NC_NETCDF4,
-) = create(name, NcVar[varlist[i] for i = 1:length(varlist)]; gatts = gatts, mode = mode)
+    add_finalizer = true,
+) = create(name, NcVar[varlist[i] for i = 1:length(varlist)]; gatts = gatts, mode = mode, add_finalizer = add_finalizer)
 
 """
     NetCDF.close(nc::NcFile)
@@ -875,8 +885,9 @@ function open(
     v::AbstractString;
     mode::Integer = NC_NOWRITE,
     readdimvar::Bool = false,
+    add_finalizer = true,
 )
-    nc = open(fil, mode = mode, readdimvar = readdimvar)
+    nc = open(fil, mode = mode, readdimvar = readdimvar, add_finalizer=add_finalizer)
     nc.vars[v]
 end
 
@@ -890,7 +901,7 @@ opens the NetCDF file `fil` and returns a `NcFile` handle. Note that it is in th
 * `mode` mode in which the file is opened, defaults to `NC_NOWRITE`, choose `NC_WRITE` for write access
 * `readdimvar` determines if dimension variables will be read into the file structure, default is `false`
 """
-function open(fil::AbstractString; mode::Integer = NC_NOWRITE, readdimvar::Bool = false)
+function open(fil::AbstractString; mode::Integer = NC_NOWRITE, readdimvar::Bool = false, add_finalizer=true)
 
     # Open netcdf file
     ncid = nc_open(fil, mode)
@@ -960,9 +971,11 @@ function open(fil::AbstractString; mode::Integer = NC_NOWRITE, readdimvar::Bool 
             atts,
             0,
             chunksize,
+            ncf,
         )
     end
     readdimvar == true && _readdimvars(ncf)
+    add_finalizer && finalizer(close,ncf)
     return ncf
 end
 
@@ -977,7 +990,7 @@ data = open("myfile.nc","myvar") do v
 end
 """
 function open(f::Function, args...; kwargs...)
-    io = open(args...; kwargs...)
+    io = open(args...;add_finalizer=false, kwargs...)
     try
         f(io)
     finally
@@ -998,7 +1011,7 @@ NetCDF.create("newfile.nc",v) do nc
 end
 """
 function create(f::Function, args...; kwargs...)
-    io = create(args...; kwargs...)
+    io = create(args...; add_finalizer=false, kwargs...)
     try
         f(io)
     finally
@@ -1196,6 +1209,7 @@ function nccreate(
     if isfile(fil)
         nc = open(fil, mode = NC_WRITE) do nc
             v.ncid = nc.ncid
+            v.ncfile = nc
             haskey(
                 nc.vars,
                 varname,
@@ -1224,6 +1238,7 @@ function nccreate(
                                 dim[i].atts,
                                 -1,
                                 (0,),
+                                nc,
                             ),
                             mode,
                         )
@@ -1246,11 +1261,11 @@ function nccreate(
             end
         end
     else
-        nc = create(fil, v, gatts = gatts, mode = mode | NC_NOCLOBBER)
-        for d in dim
+        create(fil, v, gatts = gatts, mode = mode | NC_NOCLOBBER) do nc
+          for d in dim
             !isempty(d.vals) && ncwrite(d.vals, fil, d.name)
+          end
         end
-        close(nc)
     end
     return nothing
 end

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -842,7 +842,7 @@ function create(
         end
     end
 
-    add_finalizer && finalizer(close,nc)
+    add_finalizer && finalizer(_close,nc)
 
     return nc
 end
@@ -856,17 +856,17 @@ create(
 ) = create(name, NcVar[varlist[i] for i = 1:length(varlist)]; gatts = gatts, mode = mode, add_finalizer = add_finalizer)
 
 """
-    NetCDF.close(nc::NcFile)
+    NetCDF._close(nc::NcFile)
 
 closes a NetCDF file handle
 """
-function close(nco::NcFile)
+function _close(nco::NcFile)
     #Close file
     nc_close(nco.ncid)
-    return nco.ncid
+    nothing
 end
 
-close(v::NcVar) = nc_close(v.ncid)
+close(x::Union{NcFile, NcVar}) = @warn "NetCDF.close is deprecated, since closing files is done with finalizers from now on. "
 
 
 """
@@ -975,7 +975,7 @@ function open(fil::AbstractString; mode::Integer = NC_NOWRITE, readdimvar::Bool 
         )
     end
     readdimvar == true && _readdimvars(ncf)
-    add_finalizer && finalizer(close,ncf)
+    add_finalizer && finalizer(_close,ncf)
     return ncf
 end
 

--- a/test/array-like.jl
+++ b/test/array-like.jl
@@ -12,3 +12,9 @@ NetCDF.open(fn1, "v1", mode = NC_WRITE) do v1
   v1[:,:,:] = xnew
   @test v1[:,:,:] == xnew
 end
+
+v = NetCDF.open(fn1, "v1")
+ncid = v.ncid
+v = nothing
+GC.gc()
+@test_throws NetCDF.NetCDFError NetCDF.nc_close(ncid)

--- a/test/intermediate.jl
+++ b/test/intermediate.jl
@@ -156,3 +156,10 @@ NetCDF.open(fn5) do nc5
     @test typeof(NetCDF.readvar(nc5, "dim1")) == Array{Int32,1}
     @test typeof(NetCDF.readvar(nc5, "dim2")) == Array{Float32,1}
 end
+
+# Test finalizer when working interactively with Nc objects, by trying to manually close the ncid
+nc5 = NetCDF.open(fn5)
+ncid = nc5.ncid
+nc5 = nothing
+GC.gc()
+@test_throws NetCDF.NetCDFError NetCDF.nc_close(ncid)


### PR DESCRIPTION
This will add finalizers to opened NcFile s so that calls to `NetCDF.close` become obsolete.