### PR TITLE
Update docs for finding variable names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
 keywords = ["NetCDF", "IO"]
 license = "MIT"
 desc = "NetCDF file reading and writing"
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"

--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -9,7 +9,7 @@ NetCDF.open
 ## Getting information
 
 The `NetCDF.open` function returns an object of type `NcFile` which contains meta-Information about the file and associated variables. You can index
-the `NcFile` object `nc[varname]` to retrieve an `NcVar` object and retrieve information about it. You can run `names(nc)` to get a list of available variables.
+the `NcFile` object `nc[varname]` to retrieve an `NcVar` object and retrieve information about it. You can run `keys(nc)` to get a list of available variables.
 
 Most of the following functions of the medium-level interface will use either an `NcFile` or an `NcVar` object as their first argument.
 

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -298,6 +298,7 @@ end
 #Define getindex method to retrieve a variable
 Base.getindex(nc::NcFile, i::AbstractString) = haskey(nc.vars, i) ? nc.vars[i] :
 error("NetCDF file $(nc.name) does not have a variable named $(i)")
+Base.keys(nc::NcFile) = keys(nc.vars)
 
 include("netcdf_helpers.jl")
 

--- a/test/intermediate.jl
+++ b/test/intermediate.jl
@@ -132,6 +132,7 @@ NetCDF.open(fn1, mode = NC_NOWRITE) do nc1
     @test xs == NetCDF.readvar(nc1, "vstr")
     NetCDF.readvar(nc1, "v1", start = [1, 1, 1], count = [-1, -1, -1])
     @test xs == NetCDF.nc_char2string(NetCDF.readvar(nc1, "vchar"))
+    @test sort(["vstr", "Dim2", "v1", "Dim1", "vchar"]) == sort(collect(keys(nc1)))
 end
 
 NetCDF.open(fn2, mode = NC_NOWRITE) do nc2


### PR DESCRIPTION
Fix #142 by updating documentation and adding a method for `Base.keys(::NcFile)`