### PR TITLE
Add NetCDF_jll compat for Apple M1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 [compat]
 DiskArrays = "0.2, 0.3"
 Formatting = "0.3.2, 0.4"
-NetCDF_jll = "400.701.400, 400.702.400"
+NetCDF_jll = "400.701.400, 400.702.400, 400.702.402"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This should enable the use of NetCDF on the apple M1 system.