### PR TITLE
Int64 also valid type

### DIFF
--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -38,7 +38,7 @@ After defining the dimensions, you can create `NcVar` objects with
 
     NcVar(varname , dimlist; atts=Dict{Any,Any}(), t=Float64, compress=-1)
 
-Here *varname* is the name of the variable, *dimlist* an array of type `NcDim` holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type (`Int16`, `Int32`, `Int64`, `Float32`, `Float64`) which will be translated to (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in NetCDF4 files.
+Here *varname* is the name of the variable, *dimlist* an array of type `NcDim` holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type (`Int16`, `Int32`, `Int64`, `Float32`, `Float64`) which will be translated to (`NC_SHORT`, `NC_INT`, `NC_INT64`, `NC_FLOAT`, `NC_DOUBLE`) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in NetCDF4 files.
 
 
 Having defined the variables, the NetCDF file can be created:

--- a/docs/src/intermediate.md
+++ b/docs/src/intermediate.md
@@ -38,7 +38,7 @@ After defining the dimensions, you can create `NcVar` objects with
 
     NcVar(varname , dimlist; atts=Dict{Any,Any}(), t=Float64, compress=-1)
 
-Here *varname* is the name of the variable, *dimlist* an array of type `NcDim` holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type (`Int16`, `Int32`, `Float32`, `Float64`) which will be translated to (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in NetCDF4 files.
+Here *varname* is the name of the variable, *dimlist* an array of type `NcDim` holding the dimensions associated to the variable, varattributes is a Dict holding pairs of attribute names and values. *t* is the data type that should be used for storing the variable.  You can either specify a Julia type (`Int16`, `Int32`, `Int64`, `Float32`, `Float64`) which will be translated to (`NC_SHORT`, `NC_INT`, `NC_FLOAT`, `NC_DOUBLE`) or directly specify one of the latter list. You can also set the compression level of the variable by setting *compress* to a number in the range 1..9 This has only an effect in NetCDF4 files.
 
 
 Having defined the variables, the NetCDF file can be created:


### PR DESCRIPTION
Using Int64 for the time coordinate seems to work without problems
```julia
output_startdate = DateTime(2000,1,1)
time_string = "hours since $(Dates.format(output_startdate, "yyyy-mm-dd HH:MM:0.0"))"
dim_time = NcDim("time",0,unlimited=true)
var_time = NcVar("time",dim_time,t=Int64,atts=Dict("units"=>time_string,"long_name"=>"time"))
```
and then on every time step with changing `time_hrs`
```julia
NetCDF.putvar(netcdf_file,"time",[round(Int64,time_hrs)],start=[i_out])
NetCDF.sync(netcdf_file)
```
ncdump then yields
```
milan@milanmac SpeedyWeather.jl % ncdump -c run0006/run0006.nc
netcdf run0006 {
dimensions:
	lat = 48 ;
	time = UNLIMITED ; // (41 currently)
	lon = 96 ;
	lev = 8 ;
variables:
	int64 time(time) ;
		time:units = "hours since 2000-01-01 00:00:0.0" ;
		time:long_name = "time" ;
...
 time = 0, 6, 12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90, 96, 
    102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168, 174, 180, 
    186, 192, 198, 204, 210, 216, 222, 228, 234, 240 ;
```