### PR TITLE
fix NetCDF_jll versions to avoid a broken Windows

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 [compat]
 DiskArrays = "0.2, 0.3"
 Formatting = "0.3.2, 0.4"
-NetCDF_jll = "400.701.400, 400.702.400"
+NetCDF_jll = "=400.701.400, =400.702.400"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This is the same compatibility as used in NCDatasets.jl, to mitigate https://github.com/Alexander-Barth/NCDatasets.jl/issues/164 and #151.

Hopefully we can remove these again soon when builds without the issue become available. 
Hopefully fixes CI as well.