### PR TITLE
Adjust to new estimate_chunksize

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "30363a11-5582-574a-97bb-aa9a979735b9"
 keywords = ["NetCDF", "IO"]
 license = "MIT"
 desc = "NetCDF file reading and writing"
-version = "0.11.5"
+version = "0.11.6"
 
 [deps]
 DiskArrays = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
@@ -11,7 +11,7 @@ Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 
 [compat]
-DiskArrays = "0.2, 0.3"
+DiskArrays = "0.3"
 Formatting = "0.3.2, 0.4"
 NetCDF_jll = "=400.701.400, =400.702.400"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 DiskArrays = "0.3"
 Formatting = "0.3.2, 0.4"
 NetCDF_jll = "=400.701.400, =400.702.400"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/NetCDF.jl
+++ b/src/NetCDF.jl
@@ -227,9 +227,9 @@ function writeblock!(v::NcVar, a, r::AbstractUnitRange...)
   sync(v.ncfile)
 end
 getchunksize(v::NcVar) = getchunksize(haschunks(v),v)
-getchunksize(::Chunked, v::NcVar) = reverse(map(Int64,v.chunksize))
+getchunksize(::Chunked, v::NcVar) = GridChunks(v,reverse(map(Int64,v.chunksize)))
 getchunksize(::Unchunked, v::NcVar) = estimate_chunksize(v)
-eachchunk(v::NcVar) = GridChunks(v, getchunksize(v))
+eachchunk(v::NcVar) = getchunksize(v)
 haschunks(v::NcVar) = all(iszero,v.chunksize) ? Unchunked() : Chunked()
 
 """


### PR DESCRIPTION
Fixes a compatibility error with DiskArrays 0.3 and sets the Compat entry accordingly.