### PR TITLE
Test new build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 [compat]
 DiskArrays = "0.3"
 Formatting = "0.3.2, 0.4"
-NetCDF_jll = "=400.701.400, =400.702.400"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Testing the new netcdf-c 4.9.0 build from https://github.com/JuliaPackaging/Yggdrasil/pull/5297.

This new build requires julia 1.8 or higher for now, so only test that.