### PR TITLE
Project.toml: Allow newer NetCDF_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ NetCDF_jll = "7243133f-43d8-5620-bbf4-c2c921802cf3"
 
 [compat]
 DiskArrays = "0.4"
-NetCDF_jll = "400.902.5"
+NetCDF_jll = "400.902.5, 401"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
Allow using the newest `NetCDF_jll` which wraps NetCDF 4.9.3.